### PR TITLE
Add FAIL_FAST_ENABLED environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+- feat: Add FAIL_FAST_ENABLED environment variable (#53)
+- feat: Allow environment variables to be enabled with 1, and disabled with 0
 ### Changed
+- feat: Rename FAIL_FAST environment variable to FAIL_FAST_PLUGIN (#53)
+- test(e2e): Allow some tests to be executed only in last Cypress version in order to reduce timings
 ### Fixed
 ### Removed
 ### BREAKING CHANGES
+- feat: Plugin is now enabled by default (#44). To disable it, FAIL_FAST_PLUGIN environment variable has to be explicitly set as "false". Removed FAIL_FAST environment variable, which now has not any effect.
 
 ## [1.4.0] - 2021-01-02
 

--- a/README.md
+++ b/README.md
@@ -31,40 +31,46 @@ At the top of `cypress/support/index.js`:
 import "cypress-fail-fast";
 ```
 
-## Usage
+From now, if one test fail after its last retry, the rest of tests will be skipped:
 
-Use the environment variable CYPRESS_FAIL_FAST to enable fail fast:
+![Cypress results screenshot](docs/assets/cypress-fail-fast-screenshot.png)
+
+## Configuration
+
+### Environment variables
+
+* __`FAIL_FAST_ENABLED`__: `boolean = true` Allows disabling the "fail-fast" feature globally, but it could be still enabled for specific tests or describes using [configuration by test](#configuration-by-test).
+* __`FAIL_FAST_PLUGIN`__: `boolean = true` If `false`, it disables the "fail-fast" feature totally, ignoring even plugin [configurations by test](#configuration-by-test).
+
+#### Examples
 
 ```bash
-CYPRESS_FAIL_FAST=true npm run cypress
+CYPRESS_FAIL_FAST_PLUGIN=false npm run cypress
 ```
 
-or Set the "env" key in your cypress.json configuration file:
+or set the "env" key in the `cypress.json` configuration file:
 
 ```json
 {
   "env":
   {
-    "FAIL_FAST": true
+    "FAIL_FAST_ENABLED": false
   }
 }
 ```
 
-From now, if one test fail after its last retry, the rest of tests will be skipped:
 
-![Cypress results screenshot](docs/assets/cypress-fail-fast-screenshot.png)
-
-## Custom Configurations
+### Configuration by test
 
 If you want to configure the plugin on a specific test, you can set this by using the `failFast` property in [test's configuration](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Test-Configuration). The plugin allows next config values:
 
 * __`failFast`__: Configuration for the plugin, containing any of next properties:
-  * __`enabled`__ : Indicates wheter a failure of the current test or children tests _(if configuration is [applied to a suite](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Suite-configuration))_ should produce to skip the rest of tests or not. (Note that setting this property as `true` will not have effect if the plugin is disabled globally using the `FAIL_FAST` environment variable)
+  * __`enabled`__ : Indicates wheter a failure of the current test or children tests _(if configuration is [applied to a suite](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Suite-configuration))_ should produce to skip the rest of tests or not. Note that the value defined in this property has priority over the value of the environment variable `CYPRESS_FAIL_FAST_ENABLED` _(but not over `CYPRESS_FAIL_FAST_PLUGIN`, which disables the plugin totally)_.
 
 
-### Example
+#### Example
 
-In the next example, tests are configured to `fail-fast` only in case the test with the "sanity test" description fails. If any of the other tests fails, `fail-fast` will not be applied.
+In the next example, tests are configured to "fail-fast" only in case the test with the "sanity test" description fails. If any of the other tests fails, "fail-fast" will not be applied.
 
 ```js
 describe("All tests", {
@@ -85,13 +91,45 @@ describe("All tests", {
     // Will continue executing tests if this one fails
     expect(true).to.be.true;
   });
-
-  it("third test",() => {
-    // Will continue executing tests if this one fails
-    expect(true).to.be.true;
-  });
 });
 ```
+
+### Configuration examples for usual scenarios
+
+##### You want to disable "fail-fast" in all specs except one:
+
+Set the `FAIL_FAST_ENABLED` key in the `cypress.json` configuration file:
+
+```json
+{
+  "env":
+  {
+    "FAIL_FAST_ENABLED": false
+  }
+}
+```
+
+Enable "fail-fast" in those specs you want using [configurations by test](#configuration-by-test):
+
+```js
+describe("All tests", { failFast: { enabled: true } }, () => {
+  // If any test in this describe fails, the rest of tests and specs will be skipped
+});
+```
+
+##### You want to totally disable "fail-fast" in your local environment:
+
+Set the `FAIL_FAST_PLUGIN` key in your local `cypress.env.json` configuration file:
+
+```json
+{
+  "env":
+  {
+    "FAIL_FAST_PLUGIN": false
+  }
+}
+```
+
 
 ## Usage with TypeScript
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,9 +1,34 @@
-const PLUGIN_ENVIRONMENT_VAR = "FAIL_FAST";
+const PLUGIN_ENVIRONMENT_VAR = "FAIL_FAST_PLUGIN";
+const ENABLED_ENVIRONMENT_VAR = "FAIL_FAST_ENABLED";
 const SHOULD_SKIP_TASK = "failFastShouldSkip";
 const RESET_SKIP_TASK = "failFastResetSkip";
 
+const ENVIRONMENT_DEFAULT_VALUES = {
+  [PLUGIN_ENVIRONMENT_VAR]: true,
+  [ENABLED_ENVIRONMENT_VAR]: true,
+};
+
+const TRUTHY_VALUES = [true, "true", 1, "1"];
+const FALSY_VALUES = [false, "false", 0, "0"];
+
+function valueIsOneOf(value, arrayOfValues) {
+  return arrayOfValues.includes(value);
+}
+
+function isTruthy(value) {
+  return valueIsOneOf(value, TRUTHY_VALUES);
+}
+
+function isFalsy(value) {
+  return valueIsOneOf(value, FALSY_VALUES);
+}
+
 module.exports = {
+  ENVIRONMENT_DEFAULT_VALUES,
   PLUGIN_ENVIRONMENT_VAR,
+  ENABLED_ENVIRONMENT_VAR,
   SHOULD_SKIP_TASK,
   RESET_SKIP_TASK,
+  isTruthy,
+  isFalsy,
 };

--- a/src/support.js
+++ b/src/support.js
@@ -1,15 +1,32 @@
-const { PLUGIN_ENVIRONMENT_VAR, SHOULD_SKIP_TASK, RESET_SKIP_TASK } = require("./helpers");
+const {
+  ENVIRONMENT_DEFAULT_VALUES,
+  PLUGIN_ENVIRONMENT_VAR,
+  ENABLED_ENVIRONMENT_VAR,
+  SHOULD_SKIP_TASK,
+  RESET_SKIP_TASK,
+  isFalsy,
+  isTruthy,
+} = require("./helpers");
 
 function support(Cypress, cy, beforeEach, afterEach, before) {
   function isHeaded() {
     return Cypress.browser && Cypress.browser.isHeaded;
   }
 
+  function booleanEnvironmentVarValue(environmentVarName) {
+    const defaultValue = ENVIRONMENT_DEFAULT_VALUES[environmentVarName];
+    const value = Cypress.env(environmentVarName);
+    const isTruthyValue = isTruthy(value);
+    if (!isTruthyValue && !isFalsy(value)) {
+      return defaultValue;
+    }
+    return isTruthyValue;
+  }
+
   function getFailFastEnvironmentConfig() {
     return {
-      enabled:
-        Cypress.env(PLUGIN_ENVIRONMENT_VAR) === true ||
-        Cypress.env(PLUGIN_ENVIRONMENT_VAR) === "true",
+      plugin: booleanEnvironmentVarValue(PLUGIN_ENVIRONMENT_VAR),
+      enabled: booleanEnvironmentVarValue(ENABLED_ENVIRONMENT_VAR),
     };
   }
 
@@ -24,7 +41,7 @@ function support(Cypress, cy, beforeEach, afterEach, before) {
   }
 
   function pluginIsEnabled() {
-    return getFailFastEnvironmentConfig().enabled;
+    return getFailFastEnvironmentConfig().plugin;
   }
 
   function shouldSkipRestOfTests(currentTest) {

--- a/test-e2e/commands/support/variants.js
+++ b/test-e2e/commands/support/variants.js
@@ -3,6 +3,7 @@ const VARIANTS = [
     name: "Cypress 5",
     path: "cypress-5",
     typescript: false,
+    skippable: true,
   },
   {
     name: "Cypress 6",
@@ -13,6 +14,7 @@ const VARIANTS = [
     name: "TypeScript",
     path: "typescript",
     typescript: true,
+    skippable: true,
   },
 ];
 

--- a/test-e2e/cypress-src/cypress.json
+++ b/test-e2e/cypress-src/cypress.json
@@ -1,7 +1,4 @@
 {
   "baseUrl": "http://localhost:3000",
-  "video": false,
-  "env": {
-    "FAIL_FAST": true
-  }
+  "video": false
 }

--- a/test-e2e/jest.config.js
+++ b/test-e2e/jest.config.js
@@ -13,5 +13,5 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: ["**/test/**/*.spec.js"],
-  // testMatch: ["**/test/**/test-config.spec.js"],
+  // testMatch: ["**/test/**/environment-config.spec.js"],
 };

--- a/test-e2e/package.json
+++ b/test-e2e/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "serve -l 3000",
-    "test": "jest --runInBand",
+    "test": "jest --runInBand --verbose",
     "test:build": "cross-env node commands/build.js",
     "test:install": "cd cypress-variants/cypress-5 && npm i && cd .. && cd cypress-6 && npm i && cd .. && cd typescript && npm i",
     "serve-and-test": "start-server-and-test serve http-get://localhost:3000 test",

--- a/test-e2e/test/environment-config.spec.js
+++ b/test-e2e/test/environment-config.spec.js
@@ -1,6 +1,6 @@
 const { runSpecsTests } = require("./support/testsRunner");
 
-runSpecsTests("When it is enabled using only environment variable in cypress.json", {
+runSpecsTests("When it has default configuration", {
   specs: "environment-config-only",
   specsResults: [
     {
@@ -24,7 +24,7 @@ runSpecsTests("When it is enabled using only environment variable in cypress.jso
   ],
 });
 
-runSpecsTests("When it is disabled using only environment variable", {
+runSpecsTests("When it is disabled using plugin environment variable", {
   specs: "environment-config-only",
   specsResults: [
     {
@@ -47,6 +47,35 @@ runSpecsTests("When it is disabled using only environment variable", {
     },
   ],
   env: {
-    CYPRESS_FAIL_FAST: false,
+    CYPRESS_FAIL_FAST_PLUGIN: false,
+    CYPRESS_FAIL_FAST_ENABLED: true,
+  },
+});
+
+runSpecsTests("When it is disabled using enabled environment variable", {
+  skipVariants: true,
+  specs: "environment-config-only",
+  specsResults: [
+    {
+      executed: 4,
+      passed: 3,
+      failed: 1,
+      skipped: 0,
+    },
+    {
+      executed: 4,
+      passed: 4,
+      failed: 0,
+      skipped: 0,
+    },
+    {
+      executed: 3,
+      passed: 2,
+      failed: 1,
+      skipped: 0,
+    },
+  ],
+  env: {
+    CYPRESS_FAIL_FAST_ENABLED: false,
   },
 });

--- a/test-e2e/test/support/npmCommandRunner.js
+++ b/test-e2e/test/support/npmCommandRunner.js
@@ -11,7 +11,7 @@ const npmRun = (commands, variant, env) => {
   const logData = (log) => {
     const cleanLog = stripAnsi(log.trim());
     if (cleanLog.length) {
-      // console.log(cleanLog);
+      console.log(cleanLog);
       logs.push(cleanLog);
     }
   };

--- a/test-e2e/test/support/testsRunner.js
+++ b/test-e2e/test/support/testsRunner.js
@@ -55,6 +55,9 @@ const runVariantTests = (cypressVariant, tests, options = {}) => {
 const runSpecsTests = (description, options = {}) => {
   describe(description, () => {
     cypressVariants.forEach((cypressVariant) => {
+      if (options.skipVariants && cypressVariant.skippable) {
+        return;
+      }
       runVariantTests(cypressVariant, getSpecsStatusesTests(options.specsResults), options);
     });
   });

--- a/test-e2e/test/test-config.spec.js
+++ b/test-e2e/test/test-config.spec.js
@@ -1,6 +1,6 @@
 const { runSpecsTests } = require("./support/testsRunner");
 
-runSpecsTests("When it is enabled in environment and describe but disabled in test", {
+runSpecsTests("When it is enabled in describe but disabled in test", {
   specs: "describe-enabled-test-disabled",
   specsResults: [
     {
@@ -24,7 +24,7 @@ runSpecsTests("When it is enabled in environment and describe but disabled in te
   ],
 });
 
-runSpecsTests("When it is enabled in environment, disabled in describe and enabled in test", {
+runSpecsTests("When it is disabled in describe but enabled in test", {
   specs: "describe-disabled-test-enabled",
   specsResults: [
     {
@@ -48,47 +48,21 @@ runSpecsTests("When it is enabled in environment, disabled in describe and enabl
   ],
 });
 
-runSpecsTests("When it is disabled in describe, enabled in test but disabled in environment", {
+runSpecsTests("When it is disabled in environment, disabled in describe and enabled in test", {
+  skipVariants: true,
   specs: "describe-disabled-test-enabled",
   specsResults: [
     {
       executed: 4,
-      passed: 3,
-      failed: 1,
-      skipped: 0,
-    },
-    {
-      executed: 4,
-      passed: 4,
-      failed: 0,
-      skipped: 0,
-    },
-    {
-      executed: 3,
-      passed: 2,
-      failed: 1,
-      skipped: 0,
-    },
-  ],
-  env: {
-    CYPRESS_FAIL_FAST: "false",
-  },
-});
-
-runSpecsTests("When it has configuration in grandparent suites", {
-  specs: "grandparent-describe-enabled",
-  specsResults: [
-    {
-      executed: 4,
-      passed: 3,
-      failed: 1,
-      skipped: 0,
-    },
-    {
-      executed: 4,
       passed: 1,
-      failed: 2,
-      skipped: 1,
+      failed: 1,
+      skipped: 2,
+    },
+    {
+      executed: 4,
+      passed: 0,
+      failed: 0,
+      skipped: 4,
     },
     {
       executed: 3,
@@ -97,4 +71,69 @@ runSpecsTests("When it has configuration in grandparent suites", {
       skipped: 3,
     },
   ],
+  env: {
+    CYPRESS_FAIL_FAST_ENABLED: "false",
+  },
 });
+
+runSpecsTests(
+  "When it is disabled in describe, enabled in test but plugin is disabled in environment",
+  {
+    skipVariants: true,
+    specs: "describe-disabled-test-enabled",
+    specsResults: [
+      {
+        executed: 4,
+        passed: 3,
+        failed: 1,
+        skipped: 0,
+      },
+      {
+        executed: 4,
+        passed: 4,
+        failed: 0,
+        skipped: 0,
+      },
+      {
+        executed: 3,
+        passed: 2,
+        failed: 1,
+        skipped: 0,
+      },
+    ],
+    env: {
+      CYPRESS_FAIL_FAST_PLUGIN: "false",
+    },
+  }
+);
+
+runSpecsTests(
+  "When it is disabled in environment but enabled in configuration in grandparent suites",
+  {
+    skipVariants: true,
+    specs: "grandparent-describe-enabled",
+    specsResults: [
+      {
+        executed: 4,
+        passed: 3,
+        failed: 1,
+        skipped: 0,
+      },
+      {
+        executed: 4,
+        passed: 1,
+        failed: 2,
+        skipped: 1,
+      },
+      {
+        executed: 3,
+        passed: 0,
+        failed: 0,
+        skipped: 3,
+      },
+    ],
+    env: {
+      CYPRESS_FAIL_FAST_ENABLED: "false",
+    },
+  }
+);

--- a/test/helpers.spec.js
+++ b/test/helpers.spec.js
@@ -1,0 +1,87 @@
+const { isTruthy, isFalsy } = require("../src/helpers");
+
+describe("helpers", () => {
+  describe("isTruthy", () => {
+    it("should return true when value is true as boolean", () => {
+      expect(isTruthy(true)).toEqual(true);
+    });
+
+    it("should return true when value is true as string", () => {
+      expect(isTruthy("true")).toEqual(true);
+    });
+
+    it("should return true when value is 1", () => {
+      expect(isTruthy(1)).toEqual(true);
+    });
+
+    it("should return true when value is 1 as string", () => {
+      expect(isTruthy("1")).toEqual(true);
+    });
+
+    it("should return false when value is false as boolean", () => {
+      expect(isTruthy(false)).toEqual(false);
+    });
+
+    it("should return false when value is false as string", () => {
+      expect(isTruthy("false")).toEqual(false);
+    });
+
+    it("should return false when value is 0", () => {
+      expect(isTruthy(0)).toEqual(false);
+    });
+
+    it("should return false when value is 0 as string", () => {
+      expect(isTruthy("0")).toEqual(false);
+    });
+
+    it("should return false when value is undefined", () => {
+      expect(isTruthy()).toEqual(false);
+    });
+
+    it("should return false when value is any other value", () => {
+      expect(isTruthy("foo")).toEqual(false);
+    });
+  });
+
+  describe("isFalsy", () => {
+    it("should return true when value is false as boolean", () => {
+      expect(isFalsy(false)).toEqual(true);
+    });
+
+    it("should return true when value is false as string", () => {
+      expect(isFalsy("false")).toEqual(true);
+    });
+
+    it("should return true when value is 0", () => {
+      expect(isFalsy(0)).toEqual(true);
+    });
+
+    it("should return true when value is 0 as string", () => {
+      expect(isFalsy("0")).toEqual(true);
+    });
+
+    it("should return false when value is true as boolean", () => {
+      expect(isFalsy(true)).toEqual(false);
+    });
+
+    it("should return false when value is true as string", () => {
+      expect(isFalsy("true")).toEqual(false);
+    });
+
+    it("should return false when value is 1", () => {
+      expect(isFalsy(1)).toEqual(false);
+    });
+
+    it("should return false when value is 1 as string", () => {
+      expect(isFalsy("1")).toEqual(false);
+    });
+
+    it("should return false when value is undefined", () => {
+      expect(isFalsy()).toEqual(false);
+    });
+
+    it("should return false when value is any other value", () => {
+      expect(isFalsy("foo")).toEqual(false);
+    });
+  });
+});


### PR DESCRIPTION
### Added
- feat: Add FAIL_FAST_ENABLED environment variable (#53)
- feat: Allow environment variables to be enabled with 1, and disabled with 0

### Changed
- feat: Rename FAIL_FAST environment variable to FAIL_FAST_PLUGIN (#53)
- test(e2e): Allow some tests to be executed only in last Cypress version in order to reduce timings

### BREAKING CHANGES
- feat: Plugin is now enabled by default (#44). To disable it, FAIL_FAST_PLUGIN environment variable has to be explicitly set as "false". Removed FAIL_FAST environment variable, which now has not any effect.
