### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+- feat: Add FAIL_FAST_ENABLED environment variable (#53)
+- feat: Allow environment variables to be enabled with 1, and disabled with 0
 ### Changed
+- feat: Rename FAIL_FAST environment variable to FAIL_FAST_PLUGIN (#53)
+- test(e2e): Allow some tests to be executed only in last Cypress version in order to reduce timings
 ### Fixed
 ### Removed
 ### BREAKING CHANGES
+- feat: Plugin is now enabled by default (#44). To disable it, FAIL_FAST_PLUGIN environment variable has to be explicitly set as "false". Removed FAIL_FAST environment variable, which now has not any effect.
 
 ## [1.4.0] - 2021-01-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+### Changed
+### Fixed
+### Removed
+### BREAKING CHANGES
+
+## [2.0.0] - 2021-01-17
+
+### Added
 - feat: Add FAIL_FAST_ENABLED environment variable (#53)
 - feat: Allow environment variables to be enabled with 1, and disabled with 0
+
 ### Changed
 - feat: Rename FAIL_FAST environment variable to FAIL_FAST_PLUGIN (#53)
 - test(e2e): Allow some tests to be executed only in last Cypress version in order to reduce timings
-### Fixed
-### Removed
+- chore(deps): Update devDependencies
+
 ### BREAKING CHANGES
 - feat: Plugin is now enabled by default (#44). To disable it, FAIL_FAST_PLUGIN environment variable has to be explicitly set as "false". Removed FAIL_FAST environment variable, which now has not any effect.
 

--- a/README.md
+++ b/README.md
@@ -31,40 +31,46 @@ At the top of `cypress/support/index.js`:
 import "cypress-fail-fast";
 ```
 
-## Usage
+From now, if one test fail after its last retry, the rest of tests will be skipped:
 
-Use the environment variable CYPRESS_FAIL_FAST to enable fail fast:
+![Cypress results screenshot](docs/assets/cypress-fail-fast-screenshot.png)
+
+## Configuration
+
+### Environment variables
+
+* __`FAIL_FAST_ENABLED`__: `boolean = true` Allows disabling the "fail-fast" feature globally, but it could be still enabled for specific tests or describes using [configuration by test](#configuration-by-test).
+* __`FAIL_FAST_PLUGIN`__: `boolean = true` If `false`, it disables the "fail-fast" feature totally, ignoring even plugin [configurations by test](#configuration-by-test).
+
+#### Examples
 
 ```bash
-CYPRESS_FAIL_FAST=true npm run cypress
+CYPRESS_FAIL_FAST_PLUGIN=false npm run cypress
 ```
 
-or Set the "env" key in your cypress.json configuration file:
+or set the "env" key in the `cypress.json` configuration file:
 
 ```json
 {
   "env":
   {
-    "FAIL_FAST": true
+    "FAIL_FAST_ENABLED": false
   }
 }
 ```
 
-From now, if one test fail after its last retry, the rest of tests will be skipped:
 
-![Cypress results screenshot](docs/assets/cypress-fail-fast-screenshot.png)
-
-## Custom Configurations
+### Configuration by test
 
 If you want to configure the plugin on a specific test, you can set this by using the `failFast` property in [test's configuration](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Test-Configuration). The plugin allows next config values:
 
 * __`failFast`__: Configuration for the plugin, containing any of next properties:
-  * __`enabled`__ : Indicates wheter a failure of the current test or children tests _(if configuration is [applied to a suite](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Suite-configuration))_ should produce to skip the rest of tests or not. (Note that setting this property as `true` will not have effect if the plugin is disabled globally using the `FAIL_FAST` environment variable)
+  * __`enabled`__ : Indicates wheter a failure of the current test or children tests _(if configuration is [applied to a suite](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Suite-configuration))_ should produce to skip the rest of tests or not. Note that the value defined in this property has priority over the value of the environment variable `CYPRESS_FAIL_FAST_ENABLED` _(but not over `CYPRESS_FAIL_FAST_PLUGIN`, which disables the plugin totally)_.
 
 
-### Example
+#### Example
 
-In the next example, tests are configured to `fail-fast` only in case the test with the "sanity test" description fails. If any of the other tests fails, `fail-fast` will not be applied.
+In the next example, tests are configured to "fail-fast" only in case the test with the "sanity test" description fails. If any of the other tests fails, "fail-fast" will not be applied.
 
 ```js
 describe("All tests", {
@@ -85,13 +91,45 @@ describe("All tests", {
     // Will continue executing tests if this one fails
     expect(true).to.be.true;
   });
-
-  it("third test",() => {
-    // Will continue executing tests if this one fails
-    expect(true).to.be.true;
-  });
 });
 ```
+
+### Configuration examples for usual scenarios
+
+##### You want to disable "fail-fast" in all specs except one:
+
+Set the `FAIL_FAST_ENABLED` key in the `cypress.json` configuration file:
+
+```json
+{
+  "env":
+  {
+    "FAIL_FAST_ENABLED": false
+  }
+}
+```
+
+Enable "fail-fast" in those specs you want using [configurations by test](#configuration-by-test):
+
+```js
+describe("All tests", { failFast: { enabled: true } }, () => {
+  // If any test in this describe fails, the rest of tests and specs will be skipped
+});
+```
+
+##### You want to totally disable "fail-fast" in your local environment:
+
+Set the `FAIL_FAST_PLUGIN` key in your local `cypress.env.json` configuration file:
+
+```json
+{
+  "env":
+  {
+    "FAIL_FAST_PLUGIN": false
+  }
+}
+```
+
 
 ## Usage with TypeScript
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -948,16 +948,6 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "@sinonjs/formatio": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
-      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^5.0.2"
-      }
-    },
     "@sinonjs/samsam": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.0.tgz",
@@ -6808,14 +6798,13 @@
       "dev": true
     },
     "sinon": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.2.tgz",
-      "integrity": "sha512-9Owi+RisvCZpB0bdOVFfL314I6I4YoRlz6Isi4+fr8q8YQsDPoCe5UnmNtKHRThX3negz2bXHWIuiPa42vM8EQ==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.3.tgz",
+      "integrity": "sha512-m+DyAWvqVHZtjnjX/nuShasykFeiZ+nPuEfD4G3gpvKGkXRhkF/6NSt2qN2FjZhfrcHXFzUzI+NLnk+42fnLEw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.1",
         "@sinonjs/fake-timers": "^6.0.1",
-        "@sinonjs/formatio": "^5.0.1",
         "@sinonjs/samsam": "^5.3.0",
         "diff": "^4.0.2",
         "nise": "^4.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3276,12 +3276,12 @@
       }
     },
     "find-versions": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.2.0.tgz",
-      "integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
+      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
       "dev": true,
       "requires": {
-        "semver-regex": "^2.0.0"
+        "semver-regex": "^3.1.2"
       }
     },
     "flat-cache": {
@@ -3649,21 +3649,69 @@
       "dev": true
     },
     "husky": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.6.tgz",
-      "integrity": "sha512-o6UjVI8xtlWRL5395iWq9LKDyp/9TE7XMOTvIpEVzW638UcGxTmV5cfel6fsk/jbZSTlvfGVJf2svFtybcIZag==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.7.tgz",
+      "integrity": "sha512-0fQlcCDq/xypoyYSJvEuzbDPHFf8ZF9IXKJxlrnvxABTSzK1VPT2RKYQKrcgJ+YD39swgoB6sbzywUqFxUiqjw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "ci-info": "^2.0.0",
         "compare-versions": "^3.6.0",
         "cosmiconfig": "^7.0.0",
-        "find-versions": "^3.2.0",
+        "find-versions": "^4.0.0",
         "opencollective-postinstall": "^2.0.2",
-        "pkg-dir": "^4.2.0",
+        "pkg-dir": "^5.0.0",
         "please-upgrade-node": "^3.2.0",
         "slash": "^3.0.0",
         "which-pm-runs": "^1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "pkg-dir": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^5.0.0"
+          }
+        }
       }
     },
     "iconv-lite": {
@@ -6686,9 +6734,9 @@
       "dev": true
     },
     "semver-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
-      "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
+      "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==",
       "dev": true
     },
     "set-blocking": {
@@ -7925,6 +7973,12 @@
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
       }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2786,9 +2786,9 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz",
-      "integrity": "sha512-8MaEggC2et0wSF6bUeywF7qQ46ER81irOdWS4QWxnnlAEsnzeBevk1sWh7fhpCghPpXb+8Ks7hvaft6L/xsR6g==",
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.22.0.tgz",
+      "integrity": "sha512-p30tuX3VS+NWv9nQot9xIGAHBXR0+xJVaZriEsHoJrASGCJZDJ8JLNM0YqKqI0AKm6Uxaa1VUHoNEibxRCMQHA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.1",
@@ -3389,9 +3389,9 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
-      "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
@@ -3946,9 +3946,9 @@
       }
     },
     "is-negative-zero": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
-      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
       "dev": true
     },
     "is-number": {
@@ -4760,13 +4760,13 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.1.0.tgz",
-      "integrity": "sha512-d4/UOjg+mxAWxCiF0c5UTSwyqbchkbqCvK87aBovhnh8GtysTjWmgC63tY0cJx/HzGgm9qnA147jVBdpOiQ2RA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz",
+      "integrity": "sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.1",
-        "object.assign": "^4.1.1"
+        "array-includes": "^3.1.2",
+        "object.assign": "^4.1.2"
       }
     },
     "just-extend": {
@@ -5660,9 +5660,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
       "dev": true
     },
     "object-keys": {
@@ -6737,13 +6737,14 @@
       "optional": true
     },
     "side-channel": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.3.tgz",
-      "integrity": "sha512-A6+ByhlLkksFoUepsGxfj5x1gTSrs+OydsRptUxeNCabQpCFUvcwIczgOigI8vhY/OJCnPnyE9rGiwgvr9cS1g==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
       "dev": true,
       "requires": {
-        "es-abstract": "^1.18.0-next.0",
-        "object-inspect": "^1.8.0"
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
       }
     },
     "signal-exit": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2777,9 +2777,9 @@
       "dev": true
     },
     "eslint-plugin-prettier": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.0.tgz",
-      "integrity": "sha512-tMTwO8iUWlSRZIwS9k7/E4vrTsfvsrcM5p1eftyuqWH25nKsz/o6/54I7jwQ/3zobISyC7wMy9ZsFwgTxOcOpQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz",
+      "integrity": "sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2694,9 +2694,9 @@
       }
     },
     "eslint": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.16.0.tgz",
-      "integrity": "sha512-iVWPS785RuDA4dWuhhgXTNrGxHHK3a8HLSMBgbbU59ruJDubUraXN8N5rn7kb8tG6sjg74eE0RA3YWT51eusEw==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.17.0.tgz",
+      "integrity": "sha512-zJk08MiBgwuGoxes5sSQhOtibZ75pz0J35XTRlZOk9xMffhpA9BTbQZxoXZzOl5zMbleShbGwtw+1kGferfFwQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -6309,6 +6309,12 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -7302,15 +7308,35 @@
       "dev": true
     },
     "table": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.0.4.tgz",
-      "integrity": "sha512-sBT4xRLdALd+NFBvwOz8bw4b15htyythha+q+DVZqy2RS08PPC8O2sZFgJYEY7bJvbCFKccs+WIZ/cd+xxTWCw==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.0.7.tgz",
+      "integrity": "sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==",
       "dev": true,
       "requires": {
-        "ajv": "^6.12.4",
+        "ajv": "^7.0.2",
         "lodash": "^4.17.20",
         "slice-ansi": "^4.0.0",
         "string-width": "^4.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.3.tgz",
+          "integrity": "sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
       }
     },
     "terminal-link": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-fail-fast",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jest": "26.6.3",
     "lint-staged": "10.5.3",
     "prettier": "2.2.1",
-    "sinon": "9.2.2"
+    "sinon": "9.2.3"
   },
   "lint-staged": {
     "*.js": "eslint",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint": "7.16.0",
     "eslint-config-prettier": "7.1.0",
     "eslint-plugin-prettier": "3.3.0",
-    "eslint-plugin-react": "7.21.5",
+    "eslint-plugin-react": "7.22.0",
     "husky": "4.3.6",
     "jest": "26.6.3",
     "lint-staged": "10.5.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "cypress": "6.2.0",
     "eslint": "7.17.0",
     "eslint-config-prettier": "7.1.0",
-    "eslint-plugin-prettier": "3.3.0",
+    "eslint-plugin-prettier": "3.3.1",
     "eslint-plugin-react": "7.22.0",
     "husky": "4.3.6",
     "jest": "26.6.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@stryker-mutator/jest-runner": "4.3.1",
     "babel-eslint": "10.1.0",
     "cypress": "6.2.0",
-    "eslint": "7.16.0",
+    "eslint": "7.17.0",
     "eslint-config-prettier": "7.1.0",
     "eslint-plugin-prettier": "3.3.0",
     "eslint-plugin-react": "7.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-fail-fast",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Skip the rest of Cypress tests on first failure",
   "keywords": [
     "cypress",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-config-prettier": "7.1.0",
     "eslint-plugin-prettier": "3.3.1",
     "eslint-plugin-react": "7.22.0",
-    "husky": "4.3.6",
+    "husky": "4.3.7",
     "jest": "26.6.3",
     "lint-staged": "10.5.3",
     "prettier": "2.2.1",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=cypress-fail-fast
-sonar.projectVersion=1.4.0
+sonar.projectVersion=2.0.0
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,9 +1,34 @@
-const PLUGIN_ENVIRONMENT_VAR = "FAIL_FAST";
+const PLUGIN_ENVIRONMENT_VAR = "FAIL_FAST_PLUGIN";
+const ENABLED_ENVIRONMENT_VAR = "FAIL_FAST_ENABLED";
 const SHOULD_SKIP_TASK = "failFastShouldSkip";
 const RESET_SKIP_TASK = "failFastResetSkip";
 
+const ENVIRONMENT_DEFAULT_VALUES = {
+  [PLUGIN_ENVIRONMENT_VAR]: true,
+  [ENABLED_ENVIRONMENT_VAR]: true,
+};
+
+const TRUTHY_VALUES = [true, "true", 1, "1"];
+const FALSY_VALUES = [false, "false", 0, "0"];
+
+function valueIsOneOf(value, arrayOfValues) {
+  return arrayOfValues.includes(value);
+}
+
+function isTruthy(value) {
+  return valueIsOneOf(value, TRUTHY_VALUES);
+}
+
+function isFalsy(value) {
+  return valueIsOneOf(value, FALSY_VALUES);
+}
+
 module.exports = {
+  ENVIRONMENT_DEFAULT_VALUES,
   PLUGIN_ENVIRONMENT_VAR,
+  ENABLED_ENVIRONMENT_VAR,
   SHOULD_SKIP_TASK,
   RESET_SKIP_TASK,
+  isTruthy,
+  isFalsy,
 };

--- a/src/support.js
+++ b/src/support.js
@@ -1,15 +1,32 @@
-const { PLUGIN_ENVIRONMENT_VAR, SHOULD_SKIP_TASK, RESET_SKIP_TASK } = require("./helpers");
+const {
+  ENVIRONMENT_DEFAULT_VALUES,
+  PLUGIN_ENVIRONMENT_VAR,
+  ENABLED_ENVIRONMENT_VAR,
+  SHOULD_SKIP_TASK,
+  RESET_SKIP_TASK,
+  isFalsy,
+  isTruthy,
+} = require("./helpers");
 
 function support(Cypress, cy, beforeEach, afterEach, before) {
   function isHeaded() {
     return Cypress.browser && Cypress.browser.isHeaded;
   }
 
+  function booleanEnvironmentVarValue(environmentVarName) {
+    const defaultValue = ENVIRONMENT_DEFAULT_VALUES[environmentVarName];
+    const value = Cypress.env(environmentVarName);
+    const isTruthyValue = isTruthy(value);
+    if (!isTruthyValue && !isFalsy(value)) {
+      return defaultValue;
+    }
+    return isTruthyValue;
+  }
+
   function getFailFastEnvironmentConfig() {
     return {
-      enabled:
-        Cypress.env(PLUGIN_ENVIRONMENT_VAR) === true ||
-        Cypress.env(PLUGIN_ENVIRONMENT_VAR) === "true",
+      plugin: booleanEnvironmentVarValue(PLUGIN_ENVIRONMENT_VAR),
+      enabled: booleanEnvironmentVarValue(ENABLED_ENVIRONMENT_VAR),
     };
   }
 
@@ -24,7 +41,7 @@ function support(Cypress, cy, beforeEach, afterEach, before) {
   }
 
   function pluginIsEnabled() {
-    return getFailFastEnvironmentConfig().enabled;
+    return getFailFastEnvironmentConfig().plugin;
   }
 
   function shouldSkipRestOfTests(currentTest) {

--- a/test-e2e/commands/support/variants.js
+++ b/test-e2e/commands/support/variants.js
@@ -3,6 +3,7 @@ const VARIANTS = [
     name: "Cypress 5",
     path: "cypress-5",
     typescript: false,
+    skippable: true,
   },
   {
     name: "Cypress 6",
@@ -13,6 +14,7 @@ const VARIANTS = [
     name: "TypeScript",
     path: "typescript",
     typescript: true,
+    skippable: true,
   },
 ];
 

--- a/test-e2e/cypress-src/cypress.json
+++ b/test-e2e/cypress-src/cypress.json
@@ -1,7 +1,4 @@
 {
   "baseUrl": "http://localhost:3000",
-  "video": false,
-  "env": {
-    "FAIL_FAST": true
-  }
+  "video": false
 }

--- a/test-e2e/jest.config.js
+++ b/test-e2e/jest.config.js
@@ -13,5 +13,5 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: ["**/test/**/*.spec.js"],
-  // testMatch: ["**/test/**/test-config.spec.js"],
+  // testMatch: ["**/test/**/environment-config.spec.js"],
 };

--- a/test-e2e/package.json
+++ b/test-e2e/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "serve -l 3000",
-    "test": "jest --runInBand",
+    "test": "jest --runInBand --verbose",
     "test:build": "cross-env node commands/build.js",
     "test:install": "cd cypress-variants/cypress-5 && npm i && cd .. && cd cypress-6 && npm i && cd .. && cd typescript && npm i",
     "serve-and-test": "start-server-and-test serve http-get://localhost:3000 test",

--- a/test-e2e/test/environment-config.spec.js
+++ b/test-e2e/test/environment-config.spec.js
@@ -1,6 +1,6 @@
 const { runSpecsTests } = require("./support/testsRunner");
 
-runSpecsTests("When it is enabled using only environment variable in cypress.json", {
+runSpecsTests("When it has default configuration", {
   specs: "environment-config-only",
   specsResults: [
     {
@@ -24,7 +24,7 @@ runSpecsTests("When it is enabled using only environment variable in cypress.jso
   ],
 });
 
-runSpecsTests("When it is disabled using only environment variable", {
+runSpecsTests("When it is disabled using plugin environment variable", {
   specs: "environment-config-only",
   specsResults: [
     {
@@ -47,6 +47,35 @@ runSpecsTests("When it is disabled using only environment variable", {
     },
   ],
   env: {
-    CYPRESS_FAIL_FAST: false,
+    CYPRESS_FAIL_FAST_PLUGIN: false,
+    CYPRESS_FAIL_FAST_ENABLED: true,
+  },
+});
+
+runSpecsTests("When it is disabled using enabled environment variable", {
+  skipVariants: true,
+  specs: "environment-config-only",
+  specsResults: [
+    {
+      executed: 4,
+      passed: 3,
+      failed: 1,
+      skipped: 0,
+    },
+    {
+      executed: 4,
+      passed: 4,
+      failed: 0,
+      skipped: 0,
+    },
+    {
+      executed: 3,
+      passed: 2,
+      failed: 1,
+      skipped: 0,
+    },
+  ],
+  env: {
+    CYPRESS_FAIL_FAST_ENABLED: false,
   },
 });

--- a/test-e2e/test/support/npmCommandRunner.js
+++ b/test-e2e/test/support/npmCommandRunner.js
@@ -11,7 +11,7 @@ const npmRun = (commands, variant, env) => {
   const logData = (log) => {
     const cleanLog = stripAnsi(log.trim());
     if (cleanLog.length) {
-      // console.log(cleanLog);
+      console.log(cleanLog);
       logs.push(cleanLog);
     }
   };

--- a/test-e2e/test/support/testsRunner.js
+++ b/test-e2e/test/support/testsRunner.js
@@ -55,6 +55,9 @@ const runVariantTests = (cypressVariant, tests, options = {}) => {
 const runSpecsTests = (description, options = {}) => {
   describe(description, () => {
     cypressVariants.forEach((cypressVariant) => {
+      if (options.skipVariants && cypressVariant.skippable) {
+        return;
+      }
       runVariantTests(cypressVariant, getSpecsStatusesTests(options.specsResults), options);
     });
   });

--- a/test-e2e/test/test-config.spec.js
+++ b/test-e2e/test/test-config.spec.js
@@ -1,6 +1,6 @@
 const { runSpecsTests } = require("./support/testsRunner");
 
-runSpecsTests("When it is enabled in environment and describe but disabled in test", {
+runSpecsTests("When it is enabled in describe but disabled in test", {
   specs: "describe-enabled-test-disabled",
   specsResults: [
     {
@@ -24,7 +24,7 @@ runSpecsTests("When it is enabled in environment and describe but disabled in te
   ],
 });
 
-runSpecsTests("When it is enabled in environment, disabled in describe and enabled in test", {
+runSpecsTests("When it is disabled in describe but enabled in test", {
   specs: "describe-disabled-test-enabled",
   specsResults: [
     {
@@ -48,47 +48,21 @@ runSpecsTests("When it is enabled in environment, disabled in describe and enabl
   ],
 });
 
-runSpecsTests("When it is disabled in describe, enabled in test but disabled in environment", {
+runSpecsTests("When it is disabled in environment, disabled in describe and enabled in test", {
+  skipVariants: true,
   specs: "describe-disabled-test-enabled",
   specsResults: [
     {
       executed: 4,
-      passed: 3,
-      failed: 1,
-      skipped: 0,
-    },
-    {
-      executed: 4,
-      passed: 4,
-      failed: 0,
-      skipped: 0,
-    },
-    {
-      executed: 3,
-      passed: 2,
-      failed: 1,
-      skipped: 0,
-    },
-  ],
-  env: {
-    CYPRESS_FAIL_FAST: "false",
-  },
-});
-
-runSpecsTests("When it has configuration in grandparent suites", {
-  specs: "grandparent-describe-enabled",
-  specsResults: [
-    {
-      executed: 4,
-      passed: 3,
-      failed: 1,
-      skipped: 0,
-    },
-    {
-      executed: 4,
       passed: 1,
-      failed: 2,
-      skipped: 1,
+      failed: 1,
+      skipped: 2,
+    },
+    {
+      executed: 4,
+      passed: 0,
+      failed: 0,
+      skipped: 4,
     },
     {
       executed: 3,
@@ -97,4 +71,69 @@ runSpecsTests("When it has configuration in grandparent suites", {
       skipped: 3,
     },
   ],
+  env: {
+    CYPRESS_FAIL_FAST_ENABLED: "false",
+  },
 });
+
+runSpecsTests(
+  "When it is disabled in describe, enabled in test but plugin is disabled in environment",
+  {
+    skipVariants: true,
+    specs: "describe-disabled-test-enabled",
+    specsResults: [
+      {
+        executed: 4,
+        passed: 3,
+        failed: 1,
+        skipped: 0,
+      },
+      {
+        executed: 4,
+        passed: 4,
+        failed: 0,
+        skipped: 0,
+      },
+      {
+        executed: 3,
+        passed: 2,
+        failed: 1,
+        skipped: 0,
+      },
+    ],
+    env: {
+      CYPRESS_FAIL_FAST_PLUGIN: "false",
+    },
+  }
+);
+
+runSpecsTests(
+  "When it is disabled in environment but enabled in configuration in grandparent suites",
+  {
+    skipVariants: true,
+    specs: "grandparent-describe-enabled",
+    specsResults: [
+      {
+        executed: 4,
+        passed: 3,
+        failed: 1,
+        skipped: 0,
+      },
+      {
+        executed: 4,
+        passed: 1,
+        failed: 2,
+        skipped: 1,
+      },
+      {
+        executed: 3,
+        passed: 0,
+        failed: 0,
+        skipped: 3,
+      },
+    ],
+    env: {
+      CYPRESS_FAIL_FAST_ENABLED: "false",
+    },
+  }
+);

--- a/test/helpers.spec.js
+++ b/test/helpers.spec.js
@@ -1,0 +1,87 @@
+const { isTruthy, isFalsy } = require("../src/helpers");
+
+describe("helpers", () => {
+  describe("isTruthy", () => {
+    it("should return true when value is true as boolean", () => {
+      expect(isTruthy(true)).toEqual(true);
+    });
+
+    it("should return true when value is true as string", () => {
+      expect(isTruthy("true")).toEqual(true);
+    });
+
+    it("should return true when value is 1", () => {
+      expect(isTruthy(1)).toEqual(true);
+    });
+
+    it("should return true when value is 1 as string", () => {
+      expect(isTruthy("1")).toEqual(true);
+    });
+
+    it("should return false when value is false as boolean", () => {
+      expect(isTruthy(false)).toEqual(false);
+    });
+
+    it("should return false when value is false as string", () => {
+      expect(isTruthy("false")).toEqual(false);
+    });
+
+    it("should return false when value is 0", () => {
+      expect(isTruthy(0)).toEqual(false);
+    });
+
+    it("should return false when value is 0 as string", () => {
+      expect(isTruthy("0")).toEqual(false);
+    });
+
+    it("should return false when value is undefined", () => {
+      expect(isTruthy()).toEqual(false);
+    });
+
+    it("should return false when value is any other value", () => {
+      expect(isTruthy("foo")).toEqual(false);
+    });
+  });
+
+  describe("isFalsy", () => {
+    it("should return true when value is false as boolean", () => {
+      expect(isFalsy(false)).toEqual(true);
+    });
+
+    it("should return true when value is false as string", () => {
+      expect(isFalsy("false")).toEqual(true);
+    });
+
+    it("should return true when value is 0", () => {
+      expect(isFalsy(0)).toEqual(true);
+    });
+
+    it("should return true when value is 0 as string", () => {
+      expect(isFalsy("0")).toEqual(true);
+    });
+
+    it("should return false when value is true as boolean", () => {
+      expect(isFalsy(true)).toEqual(false);
+    });
+
+    it("should return false when value is true as string", () => {
+      expect(isFalsy("true")).toEqual(false);
+    });
+
+    it("should return false when value is 1", () => {
+      expect(isFalsy(1)).toEqual(false);
+    });
+
+    it("should return false when value is 1 as string", () => {
+      expect(isFalsy("1")).toEqual(false);
+    });
+
+    it("should return false when value is undefined", () => {
+      expect(isFalsy()).toEqual(false);
+    });
+
+    it("should return false when value is any other value", () => {
+      expect(isFalsy("foo")).toEqual(false);
+    });
+  });
+});


### PR DESCRIPTION
### Added
- feat: Add FAIL_FAST_ENABLED environment variable (closes #53)
- feat: Allow environment variables to be enabled with 1, and disabled with 0

### Changed
- feat: Rename FAIL_FAST environment variable to FAIL_FAST_PLUGIN (closes #53)
- test(e2e): Allow some tests to be executed only in last Cypress version in order to reduce timings
- chore(deps): Update devDependencies

### BREAKING CHANGES
- feat: Plugin is now enabled by default (closes #44). To disable it, FAIL_FAST_PLUGIN environment variable has to be explicitly set as "false". Removed FAIL_FAST environment variable, which now has not any effect.