### PR TITLE
Feat fail test on hook fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+- feat(#119): Force the next test to fail when a "before" or "beforeEach" hook fails, so the execution is marked as "failed", and fail fast mode can be enabled.
+- feat: Add logs when skip mode is enabled, and when Cypress runner is stopped.
 ### Changed
+- refactor: Improve code readability
+- chore(deps): Update dependencies
 ### Fixed
 ### Removed
+- feat: Do not apply fail fast on other hooks apart from "before" and "beforeEach"
 ### BREAKING CHANGES
+- Fail fast is only applied on "before" and "beforeEach" hooks failures. Other hooks are ignored.
 
 ## [2.4.0] - 2021-06-10
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ From now, if one test fail after its last retry, the rest of tests will be skipp
 ### Environment variables
 
 * __`FAIL_FAST_STRATEGY`__: `'spec'|'run'|'parallel'`
-  * If `spec`, only remaining tests in current spec file are skipped.
+  * If `spec`, only remaining tests in current spec file are skipped. This mode only works in "headless" mode.
   * If `run`, all remaining tests in all spec files are skipped (default value).
   * Use `parallel` to [provide your own callbacks](#configuration-for-parallel-runs) allowing to notify from one run to the others when remaining tests should be skipped.
 * __`FAIL_FAST_ENABLED`__: `boolean = true` Allows disabling the "fail-fast" feature globally, but it could be still enabled for specific tests or describes using [configuration by test](#configuration-by-test).

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,6 +5,9 @@ const SHOULD_SKIP_TASK = "failFastShouldSkip";
 const RESET_SKIP_TASK = "failFastResetSkip";
 const LOG_TASK = "failFastLog";
 
+const STOP_MESSAGE = "Stopping Cypress runner due to a previous failure";
+const SKIP_MESSAGE = "Enabling skip mode";
+
 const STRATEGIES = ["spec", "parallel"];
 
 const TRUTHY_VALUES = [true, "true", 1, "1"];
@@ -43,6 +46,8 @@ module.exports = {
   SHOULD_SKIP_TASK,
   RESET_SKIP_TASK,
   LOG_TASK,
+  STOP_MESSAGE,
+  SKIP_MESSAGE,
   isTruthy,
   isFalsy,
   strategyIsParallel,

--- a/src/support.js
+++ b/src/support.js
@@ -5,14 +5,14 @@ const {
   STRATEGY_ENVIRONMENT_VAR,
   SHOULD_SKIP_TASK,
   RESET_SKIP_TASK,
-  LOG_TASK,
+  // LOG_TASK,
   isFalsy,
   isTruthy,
   strategyIsSpec,
 } = require("./helpers");
 
 function support(Cypress, cy, beforeEach, afterEach, before) {
-  let hookFailed, hookFailedName;
+  let hookFailed, hookFailedName, hookError;
 
   function isHeaded() {
     return Cypress.browser && Cypress.browser.isHeaded;
@@ -77,21 +77,12 @@ function support(Cypress, cy, beforeEach, afterEach, before) {
 
   beforeEach(function () {
     if (pluginIsEnabled()) {
-      if (hookFailed) {
-        // Mark skip flag as true if hook failed, and stop runner
-        cy.task(LOG_TASK, `"${hookFailedName}" hook failed, entering skip mode`);
-        cy.task(SHOULD_SKIP_TASK, true).then(() => {
+      cy.task(SHOULD_SKIP_TASK, null, { log: false }).then((value) => {
+        if (value === true) {
           this.currentTest.pending = true;
           Cypress.runner.stop();
-        });
-      } else {
-        cy.task(SHOULD_SKIP_TASK, null, { log: false }).then((value) => {
-          if (value === true) {
-            this.currentTest.pending = true;
-            Cypress.runner.stop();
-          }
-        });
-      }
+        }
+      });
     }
   });
 
@@ -133,22 +124,33 @@ function support(Cypress, cy, beforeEach, afterEach, before) {
   if (pluginIsEnabled()) {
     Cypress.runner.onRunnableRun = function (runnableRun, runnable, args) {
       const isHook = runnable.type === "hook";
+      const isBeforeHook = isHook && runnable.hookName.match(/before/);
 
       const next = args[0];
-      const wrappedNext = function (error) {
+      const setFailedFlag = function (error) {
         if (error) {
           hookFailedName = runnable.hookName;
+          hookError = error;
           hookFailed = true;
         }
         /* 
           Do not pass the error, because Cypress stops if there is an error on before hooks,
           so this plugin can't set the skip flag
         */
-        return next.call(this);
+        return next.call(/* this, error */);
       };
 
-      if (isHook) {
-        args[0] = wrappedNext;
+      const forceTestToFail = function () {
+        hookFailed = false;
+        hookError.message = `"${hookFailedName}" hook failed: ${hookError.message}`;
+        // Force next test to fail, so the plugin can set the skip flag, and the test is marked as failed
+        return next.call(this, hookError);
+      };
+
+      if (isBeforeHook) {
+        args[0] = setFailedFlag;
+      } else if (!isHook && hookFailed) {
+        args[0] = forceTestToFail;
       }
 
       return _onRunnableRun.apply(this, [runnableRun, runnable, args]);

--- a/src/support.js
+++ b/src/support.js
@@ -5,7 +5,9 @@ const {
   STRATEGY_ENVIRONMENT_VAR,
   SHOULD_SKIP_TASK,
   RESET_SKIP_TASK,
-  // LOG_TASK,
+  LOG_TASK,
+  STOP_MESSAGE,
+  SKIP_MESSAGE,
   isFalsy,
   isTruthy,
   strategyIsSpec,
@@ -75,12 +77,17 @@ function support(Cypress, cy, beforeEach, afterEach, before) {
     return currentTest.state === "failed" && currentTest.currentRetry() === currentTest.retries();
   }
 
+  function stopCypressRunner() {
+    cy.task(LOG_TASK, STOP_MESSAGE);
+    Cypress.runner.stop();
+  }
+
   beforeEach(function () {
     if (pluginIsEnabled()) {
       cy.task(SHOULD_SKIP_TASK, null, { log: false }).then((value) => {
         if (value === true) {
           this.currentTest.pending = true;
-          Cypress.runner.stop();
+          stopCypressRunner();
         }
       });
     }
@@ -95,6 +102,7 @@ function support(Cypress, cy, beforeEach, afterEach, before) {
       testHasFailed(currentTest) &&
       shouldSkipRestOfTests(currentTest)
     ) {
+      cy.task(LOG_TASK, SKIP_MESSAGE);
       cy.task(SHOULD_SKIP_TASK, true);
     }
   });
@@ -112,7 +120,7 @@ function support(Cypress, cy, beforeEach, afterEach, before) {
       } else {
         cy.task(SHOULD_SKIP_TASK, null, { log: false }).then((value) => {
           if (value === true) {
-            Cypress.runner.stop();
+            stopCypressRunner();
           }
         });
       }

--- a/test-e2e/commands/support/copy.js
+++ b/test-e2e/commands/support/copy.js
@@ -114,12 +114,14 @@ const copyCypressSpecs = (specsFolder, variant) => {
   const INTEGRATION_A_FILE = "a-file.js";
   const INTEGRATION_B_FILE = "b-file.js";
   const INTEGRATION_C_FILE = "c-file.js";
+  const INTEGRATION_D_FILE = "d-file.js";
 
   const integrationPath = path.resolve(CYPRESS_SRC_PATH, CYPRESS_INTEGRATION_PATH, specsFolder);
 
   const integrationAFile = path.resolve(integrationPath, INTEGRATION_A_FILE);
   const integrationBFile = path.resolve(integrationPath, INTEGRATION_B_FILE);
   const integrationCFile = path.resolve(integrationPath, INTEGRATION_C_FILE);
+  const integrationDFile = path.resolve(integrationPath, INTEGRATION_D_FILE);
 
   fsExtra.removeSync(destPaths.cypress.integration);
   fsExtra.ensureDirSync(destPaths.cypress.integration);
@@ -144,6 +146,15 @@ const copyCypressSpecs = (specsFolder, variant) => {
       toTypeScriptName(INTEGRATION_C_FILE, variant.typescript)
     )
   );
+  if (fsExtra.existsSync(integrationDFile)) {
+    fsExtra.copySync(
+      integrationDFile,
+      path.resolve(
+        destPaths.cypress.integration,
+        toTypeScriptName(INTEGRATION_D_FILE, variant.typescript)
+      )
+    );
+  }
 };
 
 module.exports = {

--- a/test-e2e/cypress-src/integration/before-failing/d-file.js
+++ b/test-e2e/cypress-src/integration/before-failing/d-file.js
@@ -8,20 +8,20 @@ describe("List items", () => {
     it("should display title", () => {
       cy.get("h1").should("have.text", "Items list");
     });
-
-    it("should display second item", () => {
-      cy.get("ul li:eq(1)").should("have.text", "Second item");
-    });
   });
 
-  describe("before failing", () => {
-    before(() => {
+  describe("beforeEach failing", () => {
+    beforeEach(() => {
       cy.task("log", "Executing before hook");
       expect(true).to.be.false;
     });
 
     it("should display first item", () => {
       cy.get("ul li:eq(0)").should("have.text", "First item");
+    });
+
+    it("should display second item", () => {
+      cy.get("ul li:eq(1)").should("have.text", "Second item");
     });
   });
 

--- a/test-e2e/jest.config.js
+++ b/test-e2e/jest.config.js
@@ -13,5 +13,5 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: ["**/test/**/*.spec.js"],
-  // testMatch: ["**/test/**/strategy.spec.js"],
+  // testMatch: ["**/test/**/before.spec.js"],
 };

--- a/test-e2e/test/before.spec.js
+++ b/test-e2e/test/before.spec.js
@@ -1,10 +1,18 @@
 const { runSpecsTests } = require("./support/testsRunner");
 
 runSpecsTests("When before hook fails", {
+  skipVariants: false,
   specs: "before-failing",
   specsResults: [
     {
       logBefore: true,
+      executed: 4,
+      passed: 0,
+      failed: 1,
+      skipped: 3,
+    },
+    {
+      logBefore: false,
       executed: 4,
       passed: 0,
       failed: 0,
@@ -31,15 +39,15 @@ runSpecsTests("When before hook fails", {
 });
 
 runSpecsTests("When before hook fails in spec mode", {
-  skipVariants: true,
+  skipVariants: false,
   specs: "before-failing",
   specsResults: [
     {
       logBefore: true,
       executed: 4,
       passed: 0,
-      failed: 0,
-      skipped: 4,
+      failed: 1,
+      skipped: 3,
     },
     {
       logBefore: true,
@@ -51,9 +59,16 @@ runSpecsTests("When before hook fails in spec mode", {
     {
       logBefore: true,
       executed: 4,
-      passed: 4,
-      failed: 0,
-      skipped: 0,
+      passed: 2,
+      failed: 1,
+      skipped: 1,
+    },
+    {
+      logBefore: true,
+      executed: 4,
+      passed: 1,
+      failed: 1,
+      skipped: 2,
     },
   ],
   env: {

--- a/test/support.spec.js
+++ b/test/support.spec.js
@@ -425,7 +425,7 @@ describe("support", () => {
         });
         afterEachCallback();
         await wait(200);
-        expect(cy.task.callCount).toEqual(1);
+        expect(cy.task.calledWith("failFastShouldSkip", true)).toEqual(true);
       });
     });
   };

--- a/test/support.spec.js
+++ b/test/support.spec.js
@@ -356,9 +356,18 @@ describe("support", () => {
           expect(CypressOnRunnableRun.getCall(0).args[2][0]).toBe(firstArg);
         });
 
-        it("should be called with a wrapped first arg if runnable is a hook", () => {
+        it("should be called with a wrapped first arg if runnable is a before hook", () => {
           getSupportCallbacks(config);
           runnable.type = "hook";
+          runnable.hookName = "before";
+          Cypress.runner.onRunnableRun(runnableRun, runnable, args);
+          expect(CypressOnRunnableRun.getCall(0).args[2][0]).not.toBe(firstArg);
+        });
+
+        it("should be called with a wrapped first arg if runnable is a beforeEach hook", () => {
+          getSupportCallbacks(config);
+          runnable.type = "hook";
+          runnable.hookName = "beforeEach";
           Cypress.runner.onRunnableRun(runnableRun, runnable, args);
           expect(CypressOnRunnableRun.getCall(0).args[2][0]).not.toBe(firstArg);
         });
@@ -366,6 +375,7 @@ describe("support", () => {
         it("should call to original first arg", () => {
           getSupportCallbacks(config);
           runnable.type = "hook";
+          runnable.hookName = "beforeEach";
           Cypress.runner.onRunnableRun(runnableRun, runnable, args);
           CypressOnRunnableRun.getCall(0).args[2][0]();
           expect(firstArg.callCount).toEqual(1);
@@ -374,20 +384,31 @@ describe("support", () => {
         it("should call to original first arg without error even when it is received", () => {
           getSupportCallbacks(config);
           runnable.type = "hook";
+          runnable.hookName = "beforeEach";
           Cypress.runner.onRunnableRun(runnableRun, runnable, args);
           CypressOnRunnableRun.getCall(0).args[2][0](new Error());
           expect(firstArg.getCall(0).args[1]).toBe(undefined);
         });
 
-        it("beforeEach method should call to stop runner if error is received in a hook", async () => {
+        it("next test after the hook should be forced to fail with the hook error", async () => {
           getSupportCallbacks(config);
+          const hookError = new Error("foo error message");
           runnable.type = "hook";
+          runnable.hookName = "beforeEach";
           Cypress.runner.onRunnableRun(runnableRun, runnable, args);
-          CypressOnRunnableRun.getCall(0).args[2][0](new Error());
-          beforeEachCallback();
-          await wait(200);
-          expect(cy.task.calledWith("failFastShouldSkip", true)).toEqual(true);
-          expect(Cypress.runner.stop.callCount).toEqual(1);
+          CypressOnRunnableRun.getCall(0).args[2][0](hookError);
+          runnable = {
+            type: "it",
+          };
+
+          const testCallbackSpy = sandbox.spy();
+          Cypress.runner.onRunnableRun(runnableRun, runnable, [testCallbackSpy]);
+          CypressOnRunnableRun.getCall(1).args[2][0]();
+          const testCallBackArgument = testCallbackSpy.getCall(0).args[0];
+          expect(testCallBackArgument).toBe(hookError);
+          expect(testCallBackArgument.message).toEqual(
+            '"beforeEach" hook failed: foo error message'
+          );
         });
       });
     });


### PR DESCRIPTION
### Added
- feat(#119): Force the next test to fail when a "before" or "beforeEach" hook fails, so the execution is marked as "failed", and fail fast mode can be enabled.
- feat: Add logs when skip mode is enabled, and when Cypress runner is stopped.
### Changed
- refactor: Improve code readability
- chore(deps): Update dependencies
### Fixed
### Removed
- feat: Do not apply fail fast on other hooks apart from "before" and "beforeEach"
### BREAKING CHANGES
- Fail fast is only applied on "before" and "beforeEach" hooks failures. Other hooks are ignored.