### PR TITLE
Skip nested before hooks when one fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - chore(deps): Update devDependencies
 - chore(deps): Support any NodeJs version greater than 10.x.
 
+### Fixed
+- fix(#124): Skip nested before hooks when one fails (#164)
+
 ## [3.1.1] - 2021-08-21
 
 ### Added

--- a/src/support.js
+++ b/src/support.js
@@ -147,6 +147,7 @@ function support(Cypress, cy, beforeEach, afterEach, before) {
       const isBeforeHook = isHook && runnable.hookName.match(/before/);
 
       const next = args[0];
+
       const setFailedFlag = function (error) {
         if (error) {
           hookFailedName = runnable.hookName;
@@ -157,7 +158,7 @@ function support(Cypress, cy, beforeEach, afterEach, before) {
           Do not pass the error, because Cypress stops if there is an error on before hooks,
           so this plugin can't set the skip flag
         */
-        return next.call(/* this, error */);
+        return next.call(this /*, error */);
       };
 
       const forceTestToFail = function () {
@@ -167,10 +168,13 @@ function support(Cypress, cy, beforeEach, afterEach, before) {
         return next.call(this, hookError);
       };
 
-      if (isBeforeHook) {
-        args[0] = setFailedFlag;
+      if (isBeforeHook && hookFailed) {
+        // Skip other before hooks when one failed
+        return next();
       } else if (!isHook && hookFailed) {
         args[0] = forceTestToFail;
+      } else if (isBeforeHook) {
+        args[0] = setFailedFlag;
       }
 
       return _onRunnableRun.apply(this, [runnableRun, runnable, args]);

--- a/test-e2e/cypress-src/integration/before-failing/a-file.js
+++ b/test-e2e/cypress-src/integration/before-failing/a-file.js
@@ -6,19 +6,33 @@ describe("List items", () => {
     });
   });
 
-  it("should display title", () => {
-    cy.get("h1").should("have.text", "Items list");
-  });
+  describe("List items tests", () => {
+    before(() => {
+      cy.task("log", "Executing second before hook").then(() => {
+        cy.visit("/");
+      });
+    });
 
-  it("should display first item", () => {
-    cy.get("ul li:eq(0)").should("have.text", "First item");
-  });
+    beforeEach(() => {
+      cy.task("log", "Executing beforeEach hook").then(() => {
+        cy.visit("/");
+      });
+    });
 
-  it("should display second item", () => {
-    cy.get("ul li:eq(1)").should("have.text", "Second item");
-  });
+    it("should display title", () => {
+      cy.get("h1").should("have.text", "Items list");
+    });
 
-  it("should display third item", () => {
-    cy.get("ul li:eq(2)").should("have.text", "Third item");
+    it("should display first item", () => {
+      cy.get("ul li:eq(0)").should("have.text", "First item");
+    });
+
+    it("should display second item", () => {
+      cy.get("ul li:eq(1)").should("have.text", "Second item");
+    });
+
+    it("should display third item", () => {
+      cy.get("ul li:eq(2)").should("have.text", "Third item");
+    });
   });
 });

--- a/test-e2e/test/before.spec.js
+++ b/test-e2e/test/before.spec.js
@@ -6,6 +6,8 @@ runSpecsTests("When before hook fails", {
   specsResults: [
     {
       logBefore: true,
+      logSecondBefore: false,
+      logBeforeEach: false,
       executed: 4,
       passed: 0,
       failed: 1,
@@ -44,6 +46,8 @@ runSpecsTests("When before hook fails in spec mode", {
   specsResults: [
     {
       logBefore: true,
+      logSecondBefore: false,
+      logBeforeEach: false,
       executed: 4,
       passed: 0,
       failed: 1,

--- a/test-e2e/test/support/testsRunner.js
+++ b/test-e2e/test/support/testsRunner.js
@@ -7,6 +7,8 @@ const { splitLogsBySpec } = require("./logs");
 
 const AFTER_EVENT_LOG = "Executed test:after:run event in failed test";
 const BEFORE_HOOK_LOG = "Executing before hook";
+const SECOND_BEFORE_HOOK_LOG = "Executing second before hook";
+const BEFORE_EACH_HOOK_LOG = "Executing beforeEach hook";
 
 const wait = (time = 1000) => {
   return new Promise((resolve) => {
@@ -65,7 +67,16 @@ const expectLogNotPrinted = (log, getSpecLogs) => {
 };
 
 const getSpecTests = (
-  { spec = 1, logBefore = true, executed = null, passed = null, failed = null, skipped = null },
+  {
+    spec = 1,
+    logBefore = true,
+    logSecondBefore,
+    logBeforeEach,
+    executed = null,
+    passed = null,
+    failed = null,
+    skipped = null,
+  },
   getLogs,
   getReport
 ) => {
@@ -75,6 +86,12 @@ const getSpecTests = (
       expectLogPrinted(BEFORE_HOOK_LOG, getSpecLogs);
     } else {
       expectLogNotPrinted(BEFORE_HOOK_LOG, getSpecLogs);
+    }
+    if (logSecondBefore === false) {
+      expectLogNotPrinted(SECOND_BEFORE_HOOK_LOG, getSpecLogs);
+    }
+    if (logBeforeEach === false) {
+      expectLogNotPrinted(BEFORE_EACH_HOOK_LOG, getSpecLogs);
     }
     expectTestsAmount("executed", "Tests", executed, getSpecLogs);
     expectTestsAmount("passed", "Passing", passed, getSpecLogs);

--- a/test/support.spec.js
+++ b/test/support.spec.js
@@ -390,6 +390,24 @@ describe("support", () => {
           expect(firstArg.getCall(0).args[1]).toBe(undefined);
         });
 
+        it("next before hook after the hook should be skipped", async () => {
+          getSupportCallbacks(config);
+          const hookError = new Error("foo error message");
+          runnable.type = "hook";
+          runnable.hookName = "beforeEach";
+          Cypress.runner.onRunnableRun(runnableRun, runnable, args);
+          CypressOnRunnableRun.getCall(0).args[2][0](hookError);
+          runnable = {
+            type: "hook",
+            hookName: "beforeEach",
+          };
+
+          const testCallbackSpy = () => "foo";
+          expect(Cypress.runner.onRunnableRun(runnableRun, runnable, [testCallbackSpy])).toEqual(
+            "foo"
+          );
+        });
+
         it("next test after the hook should be forced to fail with the hook error", async () => {
           getSupportCallbacks(config);
           const hookError = new Error("foo error message");


### PR DESCRIPTION
### Fixed
- fix(closes #124): Skip nested before hooks when one fails (closes #164)