### PR TITLE
Failed test message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 ### BREAKING CHANGES
 
+## [unreleased] - 2022-03-02
+- fix(#193): Do not log "Enabling skip mode" in every failed test. When a test fails, log "Failed tests: x/y", where `y` is the bail option.
+
 ## [3.4.0] - 2022-02-24
 
 ### Added

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -11,7 +11,7 @@ const RESET_FAILED_TESTS_TASK = "failFastResetFailedTests";
 
 const STOP_MESSAGE = "Stopping Cypress runner due to a previous failure";
 const SKIP_MESSAGE = "Enabling skip mode";
-const FAILED_TEST_MESSAGE = "Enabling skip mode";
+const FAILED_TEST_MESSAGE = "Failed tests";
 const LOG_PREFIX = "[fail-fast]";
 
 const ENVIRONMENT_DEFAULT_VALUES = {

--- a/src/support.js
+++ b/src/support.js
@@ -38,9 +38,10 @@ function support(Cypress, cy, beforeEach, afterEach, before) {
   }
 
   function registerFailureAndRunIfBailLimitIsReached(callback) {
-    cy.task(LOG_TASK, FAILED_TEST_MESSAGE);
     cy.task(FAILED_TESTS_TASK, true, { log: false }).then((value) => {
-      if (value >= bailConfig(Cypress)) {
+      const bail = bailConfig(Cypress);
+      cy.task(LOG_TASK, `${FAILED_TEST_MESSAGE}: ${value}/${bail}`);
+      if (value >= bail) {
         callback();
       }
     });

--- a/test/support.spec.js
+++ b/test/support.spec.js
@@ -685,6 +685,47 @@ describe("support", () => {
         failedTests: 2,
         bail: 3,
       });
+
+      describe("failed tests log", () => {
+        it("should log 1/1 when first test fails and bail is 1", async () => {
+          getSupportCallbacks({
+            failedTests: 1,
+            bail: 1,
+            testState: "failed",
+            testCurrentRetry: 3,
+            testRetries: 3,
+          });
+          afterEachCallback();
+          await wait(200);
+          expect(cy.task.calledWith("failFastLog", "Failed tests: 1/1")).toBe(true);
+        });
+
+        it("should log 1/2 when first test fails and bail is 2", async () => {
+          getSupportCallbacks({
+            failedTests: 1,
+            bail: 2,
+            testState: "failed",
+            testCurrentRetry: 3,
+            testRetries: 3,
+          });
+          afterEachCallback();
+          await wait(200);
+          expect(cy.task.calledWith("failFastLog", "Failed tests: 1/2")).toBe(true);
+        });
+
+        it("should log 3/4 when third test fails and bail is 4", async () => {
+          getSupportCallbacks({
+            failedTests: 3,
+            bail: 4,
+            testState: "failed",
+            testCurrentRetry: 3,
+            testRetries: 3,
+          });
+          afterEachCallback();
+          await wait(200);
+          expect(cy.task.calledWith("failFastLog", "Failed tests: 3/4")).toBe(true);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
- fix(#193): Do not log "Enabling skip mode" in every failed test. When a test fails, log "Failed tests: x/y", where `y` is the bail option