### PR TITLE
Release v3.4.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Test unit
         run: npm run test:unit
       - name: Test E2E
-        run: npm run test:e2e:debug
+        run: npm run test:e2e:ci
         id: test-e2e
       - name: Upload test results
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Test unit
         run: npm run test:unit
       - name: Test E2E
-        run: npm run test:e2e:ci
+        run: npm run test:e2e:debug
         id: test-e2e
       - name: Upload test results
         uses: actions/upload-artifact@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 ### BREAKING CHANGES
 
-## [unreleased] - 2022-03-02
+## [3.4.1] - 2022-03-02
+
+### Fixed
 - fix(#193): Do not log "Enabling skip mode" in every failed test. When a test fails, log "Failed tests: x/y", where `y` is the bail option.
+
+### Changed
+- chore(deps): Update devDependencies
 
 ## [3.4.0] - 2022-02-24
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-fail-fast",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-fail-fast",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-fail-fast",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Skip the rest of Cypress tests on first failure",
   "keywords": [
     "cypress",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=javierbrea_cypress-fail-fast
-sonar.projectVersion=3.4.0
+sonar.projectVersion=3.4.1
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/test-e2e/jest.config.js
+++ b/test-e2e/jest.config.js
@@ -16,5 +16,5 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: ["**/test/**/*.spec.js"],
-  testMatch: ["**/test/**/parallel.spec.js"],
+  // testMatch: ["**/test/**/parallel.spec.js"],
 };

--- a/test-e2e/jest.config.js
+++ b/test-e2e/jest.config.js
@@ -16,5 +16,5 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: ["**/test/**/*.spec.js"],
-  // testMatch: ["**/test/**/parallel.spec.js"],
+  testMatch: ["**/test/**/parallel.spec.js"],
 };

--- a/test-e2e/test/parallel.spec.js
+++ b/test-e2e/test/parallel.spec.js
@@ -16,6 +16,7 @@ runParallelSpecsTests(
       cypressVersion: "latest",
       pluginFile: "parallel-preprocessor-babel-config",
       specs: "parallel-failing",
+      delay: 2000,
       specsResults: [
         {
           logBefore: true,
@@ -87,6 +88,7 @@ runParallelSpecsTests(
       cypressVersion: "8",
       pluginFile: "parallel-preprocessor-babel-config",
       specs: "parallel-failing",
+      delay: 2000,
       specsResults: [
         {
           logBefore: true,
@@ -158,6 +160,7 @@ runParallelSpecsTests(
       cypressVersion: "latest",
       pluginFile: "parallel-preprocessor-babel-config",
       specs: "parallel-failing",
+      delay: 2000,
       specsResults: [
         {
           logBefore: true,

--- a/test-e2e/test/parallel.spec.js
+++ b/test-e2e/test/parallel.spec.js
@@ -16,7 +16,7 @@ runParallelSpecsTests(
       cypressVersion: "latest",
       pluginFile: "parallel-preprocessor-babel-config",
       specs: "parallel-failing",
-      delay: 2000,
+      delay: 5000,
       specsResults: [
         {
           logBefore: true,
@@ -88,7 +88,7 @@ runParallelSpecsTests(
       cypressVersion: "8",
       pluginFile: "parallel-preprocessor-babel-config",
       specs: "parallel-failing",
-      delay: 2000,
+      delay: 5000,
       specsResults: [
         {
           logBefore: true,
@@ -160,7 +160,7 @@ runParallelSpecsTests(
       cypressVersion: "latest",
       pluginFile: "parallel-preprocessor-babel-config",
       specs: "parallel-failing",
-      delay: 2000,
+      delay: 5000,
       specsResults: [
         {
           logBefore: true,


### PR DESCRIPTION
### Fixed
- fix(#193): Do not log "Enabling skip mode" in every failed test. When a test fails, log "Failed tests: x/y", where `y` is the bail option.

### Changed
- chore(deps): Update devDependencies

closes #193 