### PR TITLE
Do not use optional chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 ### BREAKING CHANGES
 
+## [unreleased]
+
+### Fixed
+- fix(#290): Do not use optional chaining. It was producing an error in Cypress. See https://github.com/cypress-io/cypress/issues/9298
+
 ## [7.0.2] - 2023-08-16
 
 ### Changed

--- a/src/helpers/cypress.js
+++ b/src/helpers/cypress.js
@@ -1,5 +1,5 @@
 function isHeaded(Cypress) {
-  return Cypress.browser?.isHeaded;
+  return Cypress.browser && Cypress.browser.isHeaded;
 }
 
 function testHasFailed(currentTest) {
@@ -55,16 +55,22 @@ function getTestConfig(test) {
   }
   // Cypress >9
   if (
-    test.ctx?.test?._testConfig?.testConfigList?.[
-      test.ctx?.test?._testConfig?.testConfigList?.length - 1
-    ]?.overrides
+    test.ctx &&
+    test.ctx.test &&
+    test.ctx.test._testConfig &&
+    test.ctx.test._testConfig.testConfigList &&
+    test.ctx.test._testConfig.testConfigList[
+      test.ctx.test._testConfig.testConfigList.length - 1
+    ] &&
+    test.ctx.test._testConfig.testConfigList[test.ctx.test._testConfig.testConfigList.length - 1]
+      .overrides
   ) {
     return test.ctx.test._testConfig.testConfigList[
       test.ctx.test._testConfig.testConfigList.length - 1
     ].overrides;
   }
   // Cypress >6.7
-  if (test.ctx?.test?._testConfig) {
+  if (test.ctx && test.ctx.test && test.ctx.test._testConfig) {
     return test.ctx.test._testConfig;
   }
   return {};


### PR DESCRIPTION
### Fixed
- fix(#290): Do not use optional chaining. It was producing an error in Cypress. See https://github.com/cypress-io/cypress/issues/9298