### PR TITLE
feat: Support async hooks and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - feat: Support configuration via `Cypress.expose()` and new `failFast*` options.
 - feat: Add `failFastIgnorePerTestConfig` option to control whether per-test configuration is honored.
+- feat: Support async hooks in `onFailFastTriggered` and `shouldTriggerFailFast` by allowing them to return a `Promise`. Added error handling with warnings for hooks.
 - refactor: Migrate plugin and tests to TypeScript.
 - test(e2e): Simplify and speed up E2E tests.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+- feat: Support async hooks in `onFailFastTriggered` and `shouldTriggerFailFast` by allowing them to return a `Promise`. Added error handling with warnings for hooks.
 ### Changed
 ### Fixed
 ### Removed
@@ -30,7 +31,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - feat: Support configuration via `Cypress.expose()` and new `failFast*` options.
 - feat: Add `failFastIgnorePerTestConfig` option to control whether per-test configuration is honored.
-- feat: Support async hooks in `onFailFastTriggered` and `shouldTriggerFailFast` by allowing them to return a `Promise`. Added error handling with warnings for hooks.
 - refactor: Migrate plugin and tests to TypeScript.
 - test(e2e): Simplify and speed up E2E tests.
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ Supported hooks:
     - `fullTitle`: The full title of the test that failed, including the titles of its parent suites.
 - `shouldTriggerFailFast`: Trigger fail-fast mode at any moment based on custom logic. For example, you can use this hook to trigger fail-fast mode when a certain threshold of failures is reached across parallel runs. The hook should return `true` to trigger fail-fast mode or `false` to continue without triggering it. This hook is called before each test execution, so be careful with the performance of the logic implemented here.
 
+Both `onFailFastTriggered` and `shouldTriggerFailFast` support returning a Promise, allowing you to execute asynchronous operations like API calls or database queries inside the hooks. If a Promise is returned, the plugin will wait for it to resolve before continuing. If a hook throws an error or returns a rejected Promise, the error will be caught, a warning will be logged, and execution will continue normally (in the case of `shouldTriggerFailFast`, it will assume `false`).
+
 Here you have an example of how to use these hooks to coordinate multiple parallel runs using a shared file as a flag:
 
 ```ts

--- a/src/Node/Tasks.spec.ts
+++ b/src/Node/Tasks.spec.ts
@@ -114,7 +114,9 @@ describe("registerFailFastTasks", () => {
     };
 
     expect(
-      await tasks[TRIGGER_FAIL_FAST_TASK](createEnableSkipTaskPayload(failedTest)),
+      await tasks[TRIGGER_FAIL_FAST_TASK](
+        createEnableSkipTaskPayload(failedTest),
+      ),
     ).toBe(true);
     expect(await tasks[SHOULD_SKIP_TASK]()).toBe(true);
   });
@@ -168,7 +170,9 @@ describe("registerFailFastTasks", () => {
 
   it("logs error and returns false when shouldTriggerFailFast hook fails", async () => {
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-    const shouldTriggerFailFast = jest.fn<() => Promise<boolean>>().mockRejectedValue(new Error("Hook failed"));
+    const shouldTriggerFailFast = jest
+      .fn<() => Promise<boolean>>()
+      .mockRejectedValue(new Error("Hook failed"));
     const tasks = createRegisteredTasks({
       hooks: {
         shouldTriggerFailFast,
@@ -177,26 +181,36 @@ describe("registerFailFastTasks", () => {
 
     expect(await tasks[SHOULD_SKIP_TASK]()).toBe(false);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Ignored error in shouldTriggerFailFast hook: Error: Hook failed")
+      expect.stringContaining(
+        "Ignored error in shouldTriggerFailFast hook: Error: Hook failed",
+      ),
     );
     warnSpy.mockRestore();
   });
 
   it("logs error and continues when onFailFastTriggered hook fails", async () => {
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-    const onFailFastTriggered = jest.fn<() => Promise<void>>().mockRejectedValue(new Error("Hook failed"));
+    const onFailFastTriggered = jest
+      .fn<() => Promise<void>>()
+      .mockRejectedValue(new Error("Hook failed"));
     const tasks = createRegisteredTasks({
       hooks: {
         onFailFastTriggered,
       },
     });
 
-    expect(await tasks[TRIGGER_FAIL_FAST_TASK](createEnableSkipTaskPayload({
-      name: "a test",
-      fullTitle: "suite a test",
-    }))).toBe(true);
+    expect(
+      await tasks[TRIGGER_FAIL_FAST_TASK](
+        createEnableSkipTaskPayload({
+          name: "a test",
+          fullTitle: "suite a test",
+        }),
+      ),
+    ).toBe(true);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Ignored error in onFailFastTriggered hook: Error: Hook failed")
+      expect.stringContaining(
+        "Ignored error in onFailFastTriggered hook: Error: Hook failed",
+      ),
     );
     warnSpy.mockRestore();
   });
@@ -220,7 +234,9 @@ describe("registerFailFastTasks", () => {
       },
     });
 
-    await tasks[TRIGGER_FAIL_FAST_TASK](createEnableSkipTaskPayload(failedTest));
+    await tasks[TRIGGER_FAIL_FAST_TASK](
+      createEnableSkipTaskPayload(failedTest),
+    );
 
     expect(onFailFastTriggered).toHaveBeenCalledTimes(1);
     expect(onFailFastTriggered).toHaveBeenCalledWith({
@@ -253,7 +269,9 @@ describe("registerFailFastTasks", () => {
       },
     );
 
-    await tasks[TRIGGER_FAIL_FAST_TASK](createEnableSkipTaskPayload(failedTest));
+    await tasks[TRIGGER_FAIL_FAST_TASK](
+      createEnableSkipTaskPayload(failedTest),
+    );
 
     expect(onFailFastTriggered).toHaveBeenCalledWith({
       strategy: SPEC_STRATEGY,
@@ -278,7 +296,9 @@ describe("registerFailFastTasks", () => {
     });
 
     await tasks[SHOULD_SKIP_TASK]();
-    await tasks[TRIGGER_FAIL_FAST_TASK](createEnableSkipTaskPayload(failedTest));
+    await tasks[TRIGGER_FAIL_FAST_TASK](
+      createEnableSkipTaskPayload(failedTest),
+    );
     tasks[RESET_SKIP_TASK]();
     await tasks[SHOULD_SKIP_TASK]();
 

--- a/src/Node/Tasks.spec.ts
+++ b/src/Node/Tasks.spec.ts
@@ -100,13 +100,13 @@ describe("registerFailFastTasks", () => {
     });
   });
 
-  it("returns false from should-skip task by default", () => {
+  it("returns false from should-skip task by default", async () => {
     const tasks = createRegisteredTasks();
 
-    expect(tasks[SHOULD_SKIP_TASK]()).toBe(false);
+    expect(await tasks[SHOULD_SKIP_TASK]()).toBe(false);
   });
 
-  it("enables skip mode when trigger task receives failed test payload", () => {
+  it("enables skip mode when trigger task receives failed test payload", async () => {
     const tasks = createRegisteredTasks();
     const failedTest = {
       name: "a test",
@@ -114,15 +114,15 @@ describe("registerFailFastTasks", () => {
     };
 
     expect(
-      tasks[TRIGGER_FAIL_FAST_TASK](createEnableSkipTaskPayload(failedTest)),
+      await tasks[TRIGGER_FAIL_FAST_TASK](createEnableSkipTaskPayload(failedTest)),
     ).toBe(true);
-    expect(tasks[SHOULD_SKIP_TASK]()).toBe(true);
+    expect(await tasks[SHOULD_SKIP_TASK]()).toBe(true);
   });
 
-  it("resets skip mode when reset-skip task is executed", () => {
+  it("resets skip mode when reset-skip task is executed", async () => {
     const tasks = createRegisteredTasks();
 
-    tasks[TRIGGER_FAIL_FAST_TASK](
+    await tasks[TRIGGER_FAIL_FAST_TASK](
       createEnableSkipTaskPayload({
         name: "a test",
         fullTitle: "suite a test",
@@ -130,10 +130,10 @@ describe("registerFailFastTasks", () => {
     );
 
     expect(tasks[RESET_SKIP_TASK]()).toBeNull();
-    expect(tasks[SHOULD_SKIP_TASK]()).toBe(false);
+    expect(await tasks[SHOULD_SKIP_TASK]()).toBe(false);
   });
 
-  it("uses shouldTriggerFailFast hook and caches true result", () => {
+  it("uses shouldTriggerFailFast hook and caches true result", async () => {
     const shouldTriggerFailFast = jest
       .fn<() => boolean>()
       .mockReturnValueOnce(true)
@@ -145,12 +145,12 @@ describe("registerFailFastTasks", () => {
       },
     });
 
-    expect(tasks[SHOULD_SKIP_TASK]()).toBe(true);
-    expect(tasks[SHOULD_SKIP_TASK]()).toBe(true);
+    expect(await tasks[SHOULD_SKIP_TASK]()).toBe(true);
+    expect(await tasks[SHOULD_SKIP_TASK]()).toBe(true);
     expect(shouldTriggerFailFast).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps skip mode disabled when shouldTriggerFailFast returns false", () => {
+  it("keeps skip mode disabled when shouldTriggerFailFast returns false", async () => {
     const shouldTriggerFailFast = jest
       .fn<() => boolean>()
       .mockReturnValue(false);
@@ -161,12 +161,47 @@ describe("registerFailFastTasks", () => {
       },
     });
 
-    expect(tasks[SHOULD_SKIP_TASK]()).toBe(false);
-    expect(tasks[SHOULD_SKIP_TASK]()).toBe(false);
+    expect(await tasks[SHOULD_SKIP_TASK]()).toBe(false);
+    expect(await tasks[SHOULD_SKIP_TASK]()).toBe(false);
     expect(shouldTriggerFailFast).toHaveBeenCalledTimes(2);
   });
 
-  it("calls onFailFastTriggered when enabling skip mode with payload", () => {
+  it("logs error and returns false when shouldTriggerFailFast hook fails", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const shouldTriggerFailFast = jest.fn<() => Promise<boolean>>().mockRejectedValue(new Error("Hook failed"));
+    const tasks = createRegisteredTasks({
+      hooks: {
+        shouldTriggerFailFast,
+      },
+    });
+
+    expect(await tasks[SHOULD_SKIP_TASK]()).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Ignored error in shouldTriggerFailFast hook: Error: Hook failed")
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("logs error and continues when onFailFastTriggered hook fails", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const onFailFastTriggered = jest.fn<() => Promise<void>>().mockRejectedValue(new Error("Hook failed"));
+    const tasks = createRegisteredTasks({
+      hooks: {
+        onFailFastTriggered,
+      },
+    });
+
+    expect(await tasks[TRIGGER_FAIL_FAST_TASK](createEnableSkipTaskPayload({
+      name: "a test",
+      fullTitle: "suite a test",
+    }))).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Ignored error in onFailFastTriggered hook: Error: Hook failed")
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("calls onFailFastTriggered when enabling skip mode with payload", async () => {
     const onFailFastTriggered =
       jest.fn<
         (context: {
@@ -185,7 +220,7 @@ describe("registerFailFastTasks", () => {
       },
     });
 
-    tasks[TRIGGER_FAIL_FAST_TASK](createEnableSkipTaskPayload(failedTest));
+    await tasks[TRIGGER_FAIL_FAST_TASK](createEnableSkipTaskPayload(failedTest));
 
     expect(onFailFastTriggered).toHaveBeenCalledTimes(1);
     expect(onFailFastTriggered).toHaveBeenCalledWith({
@@ -194,7 +229,7 @@ describe("registerFailFastTasks", () => {
     });
   });
 
-  it("passes spec strategy to hooks when configured", () => {
+  it("passes spec strategy to hooks when configured", async () => {
     const onFailFastTriggered =
       jest.fn<
         (context: {
@@ -218,7 +253,7 @@ describe("registerFailFastTasks", () => {
       },
     );
 
-    tasks[TRIGGER_FAIL_FAST_TASK](createEnableSkipTaskPayload(failedTest));
+    await tasks[TRIGGER_FAIL_FAST_TASK](createEnableSkipTaskPayload(failedTest));
 
     expect(onFailFastTriggered).toHaveBeenCalledWith({
       strategy: SPEC_STRATEGY,
@@ -226,7 +261,7 @@ describe("registerFailFastTasks", () => {
     });
   });
 
-  it("calls shouldTriggerFailFast without arguments", () => {
+  it("calls shouldTriggerFailFast without arguments", async () => {
     const shouldTriggerFailFast = jest
       .fn<() => boolean>()
       .mockReturnValue(false);
@@ -242,10 +277,10 @@ describe("registerFailFastTasks", () => {
       },
     });
 
-    tasks[SHOULD_SKIP_TASK]();
-    tasks[TRIGGER_FAIL_FAST_TASK](createEnableSkipTaskPayload(failedTest));
+    await tasks[SHOULD_SKIP_TASK]();
+    await tasks[TRIGGER_FAIL_FAST_TASK](createEnableSkipTaskPayload(failedTest));
     tasks[RESET_SKIP_TASK]();
-    tasks[SHOULD_SKIP_TASK]();
+    await tasks[SHOULD_SKIP_TASK]();
 
     expect(shouldTriggerFailFast).toHaveBeenNthCalledWith(1);
     expect(shouldTriggerFailFast).toHaveBeenNthCalledWith(2);

--- a/src/Node/Tasks.ts
+++ b/src/Node/Tasks.ts
@@ -44,7 +44,6 @@ export function registerFailFastTasks(
       const result = await shouldTriggerFailFastCallback();
       return result || false;
     } catch (error) {
-      // eslint-disable-next-line no-console
       console.warn(
         `${chalk.yellow(LOG_PREFIX)} Ignored error in shouldTriggerFailFast hook: ${error}`,
       );
@@ -77,7 +76,9 @@ export function registerFailFastTasks(
     [SHOULD_SKIP_TASK]: async function () {
       return await shouldSkip();
     },
-    [TRIGGER_FAIL_FAST_TASK]: async function (value: TriggerFailFastTaskPayload) {
+    [TRIGGER_FAIL_FAST_TASK]: async function (
+      value: TriggerFailFastTaskPayload,
+    ) {
       if (onFailFastTriggeredCallback) {
         try {
           await onFailFastTriggeredCallback({
@@ -85,7 +86,6 @@ export function registerFailFastTasks(
             test: value.test,
           });
         } catch (error) {
-          // eslint-disable-next-line no-console
           console.warn(
             `${chalk.yellow(LOG_PREFIX)} Ignored error in onFailFastTriggered hook: ${error}`,
           );

--- a/src/Node/Tasks.ts
+++ b/src/Node/Tasks.ts
@@ -35,24 +35,33 @@ export function registerFailFastTasks(
     pluginConfig.hooks?.shouldTriggerFailFast;
   const onFailFastTriggeredCallback = pluginConfig.hooks?.onFailFastTriggered;
 
-  function shouldTriggerFailFastFromHook() {
+  async function shouldTriggerFailFastFromHook() {
     if (!shouldTriggerFailFastCallback) {
       return false;
     }
 
-    return shouldTriggerFailFastCallback() || false;
+    try {
+      const result = await shouldTriggerFailFastCallback();
+      return result || false;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `${chalk.yellow(LOG_PREFIX)} Ignored error in shouldTriggerFailFast hook: ${error}`,
+      );
+      return false;
+    }
   }
 
   /**
    * Computes whether remaining tests should be skipped.
    * @returns `true` when skip mode is active.
    */
-  const shouldSkip = () => {
+  const shouldSkip = async () => {
     if (shouldSkipFlag) {
       return shouldSkipFlag;
     }
 
-    if (shouldTriggerFailFastFromHook()) {
+    if (await shouldTriggerFailFastFromHook()) {
       shouldSkipFlag = true;
     }
 
@@ -65,20 +74,27 @@ export function registerFailFastTasks(
       shouldSkipFlag = false;
       return null;
     },
-    [SHOULD_SKIP_TASK]: function () {
-      return shouldSkip();
+    [SHOULD_SKIP_TASK]: async function () {
+      return await shouldSkip();
     },
-    [TRIGGER_FAIL_FAST_TASK]: function (value: TriggerFailFastTaskPayload) {
+    [TRIGGER_FAIL_FAST_TASK]: async function (value: TriggerFailFastTaskPayload) {
       if (onFailFastTriggeredCallback) {
-        onFailFastTriggeredCallback({
-          strategy,
-          test: value.test,
-        });
+        try {
+          await onFailFastTriggeredCallback({
+            strategy,
+            test: value.test,
+          });
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `${chalk.yellow(LOG_PREFIX)} Ignored error in onFailFastTriggered hook: ${error}`,
+          );
+        }
       }
 
       shouldSkipFlag = true;
 
-      return shouldSkip();
+      return await shouldSkip();
     },
     [FAILED_TESTS_TASK]: function (value: boolean) {
       if (value === true) {

--- a/src/Node/Tasks.types.ts
+++ b/src/Node/Tasks.types.ts
@@ -29,13 +29,15 @@ export type FailFastHooks = {
   /**
    * Runs when fail-fast mode is triggered from a failed test.
    */
-  onFailFastTriggered?(context: OnFailFastTriggeredHookContext): void;
+  onFailFastTriggered?(
+    context: OnFailFastTriggeredHookContext,
+  ): void | Promise<void>;
 
   /**
    * Runs before each test execution to decide if fail-fast should be triggered.
    * Returning true enables skip mode.
    */
-  shouldTriggerFailFast?(): boolean;
+  shouldTriggerFailFast?(): boolean | Promise<boolean>;
 };
 
 /**

--- a/test-e2e/cypress-latest/cypress.config.js
+++ b/test-e2e/cypress-latest/cypress.config.js
@@ -33,7 +33,8 @@ module.exports = {
         const execute = () => {
           executedBeforeEach++;
           if (
-            executedBeforeEach > Number(process.env.ENABLE_SKIP_MODE_AFTER_TESTS)
+            executedBeforeEach >
+            Number(process.env.ENABLE_SKIP_MODE_AFTER_TESTS)
           ) {
             if (!consolePrinted) {
               consolePrinted = true;

--- a/test-e2e/cypress-latest/cypress.config.js
+++ b/test-e2e/cypress-latest/cypress.config.js
@@ -9,29 +9,51 @@ module.exports = {
     baseUrl: "http://localhost:3000",
     setupNodeEvents(on, config) {
       const onFailFastTriggeredHook = ({ strategy, test }) => {
-        // eslint-disable-next-line no-console
-        console.log(
-          `Fail-fast triggered with strategy "${strategy}" by test "${test.fullTitle}"`,
-        );
+        const execute = () => {
+          // eslint-disable-next-line no-console
+          console.log(
+            `Fail-fast triggered with strategy "${strategy}" by test "${test.fullTitle}"`,
+          );
+        };
+        if (process.env.ASYNC_HOOKS === "true") {
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              execute();
+              resolve();
+            }, 2000);
+          });
+        }
+        execute();
       };
 
       let executedBeforeEach = 0;
       let consolePrinted = false;
 
       const shouldTriggerFailFastHook = () => {
-        executedBeforeEach++;
-        if (
-          executedBeforeEach > Number(process.env.ENABLE_SKIP_MODE_AFTER_TESTS)
-        ) {
-          if (!consolePrinted) {
-            consolePrinted = true;
-            // eslint-disable-next-line no-console
-            console.log(
-              `Custom shouldTriggerFailFast hook triggered fail-fast mode after ${executedBeforeEach - 1} tests executed`,
-            );
+        const execute = () => {
+          executedBeforeEach++;
+          if (
+            executedBeforeEach > Number(process.env.ENABLE_SKIP_MODE_AFTER_TESTS)
+          ) {
+            if (!consolePrinted) {
+              consolePrinted = true;
+              // eslint-disable-next-line no-console
+              console.log(
+                `Custom shouldTriggerFailFast hook triggered fail-fast mode after ${executedBeforeEach - 1} tests executed`,
+              );
+            }
+            return true;
           }
-          return true;
+          return false;
+        };
+        if (process.env.ASYNC_HOOKS === "true") {
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              resolve(execute());
+            }, 2000);
+          });
         }
+        return execute();
       };
 
       const hooks = {};

--- a/test-e2e/cypress-latest/cypress.config.js
+++ b/test-e2e/cypress-latest/cypress.config.js
@@ -8,6 +8,9 @@ module.exports = {
   e2e: {
     baseUrl: "http://localhost:3000",
     setupNodeEvents(on, config) {
+      /**
+       * @returns {void | Promise<void>}
+       */
       const onFailFastTriggeredHook = ({ strategy, test }) => {
         const execute = () => {
           // eslint-disable-next-line no-console
@@ -23,12 +26,15 @@ module.exports = {
             }, 2000);
           });
         }
-        execute();
+        return execute();
       };
 
       let executedBeforeEach = 0;
       let consolePrinted = false;
 
+      /**
+       * @returns {boolean | Promise<boolean>}
+       */
       const shouldTriggerFailFastHook = () => {
         const execute = () => {
           executedBeforeEach++;

--- a/test-e2e/runner/specs/hooks.spec.ts
+++ b/test-e2e/runner/specs/hooks.spec.ts
@@ -74,3 +74,80 @@ runSpecsTests("When shouldTriggerFailFast is enabled", {
     enableSkipModeAfterTests: 6,
   },
 });
+
+runSpecsTests("When onFailFastTriggered is async", {
+  cypressVariant: "cypress-latest",
+  specsFolder: "grandparent-describe-enabled",
+  config: {
+    failFastStrategy: "spec",
+    failFastIgnorePerTestConfig: true,
+    failFastBail: 2,
+  },
+  specsResults: [
+    {
+      executed: 4,
+      passed: 3,
+      failed: 1,
+      pending: 0,
+    },
+    {
+      executed: 4,
+      passed: 1,
+      failed: 2,
+      pending: 1,
+    },
+    {
+      executed: 3,
+      passed: 2,
+      failed: 1,
+      pending: 0,
+    },
+  ],
+  hooks: {
+    enableOnFailFastTriggered: true,
+    asyncHooks: true,
+    expectFailFastTriggeredLog: {
+      strategy: "spec",
+      test: {
+        name: "should display second item",
+        fullTitle:
+          "List items fail-fast enabled Another describe Another describe should display second item",
+      },
+    },
+  },
+});
+
+runSpecsTests("When shouldTriggerFailFast is async", {
+  cypressVariant: "cypress-latest",
+  specsFolder: "grandparent-describe-enabled",
+  config: {
+    failFastStrategy: "spec",
+    failFastIgnorePerTestConfig: true,
+    failFastBail: 4,
+  },
+  specsResults: [
+    {
+      executed: 4,
+      passed: 3,
+      failed: 1,
+      pending: 0,
+    },
+    {
+      executed: 4,
+      passed: 1,
+      failed: 1,
+      pending: 2,
+    },
+    {
+      executed: 3,
+      passed: 0,
+      failed: 0,
+      pending: 3,
+    },
+  ],
+  hooks: {
+    enableShouldTriggerFailFast: true,
+    enableSkipModeAfterTests: 6,
+    asyncHooks: true,
+  },
+});

--- a/test-e2e/runner/specs/support/TestsRunner.ts
+++ b/test-e2e/runner/specs/support/TestsRunner.ts
@@ -33,6 +33,8 @@ type HooksConfig = {
   enableShouldTriggerFailFast?: boolean;
   /** Number of failed tests required to trigger fail-fast mode when `shouldTriggerFailFast` is enabled. */
   enableSkipModeAfterTests?: number;
+  /** When `true`, hooks will be async and return a Promise with a timeout. */
+  asyncHooks?: boolean;
 };
 
 /** Expected test counts for a single Cypress spec file. */
@@ -304,9 +306,12 @@ const runVariantTests = (
           ENABLE_SKIP_MODE_AFTER_TESTS: options.hooks?.enableSkipModeAfterTests
             ? String(options.hooks.enableSkipModeAfterTests)
             : undefined,
+          ASYNC_HOOKS: options.hooks?.asyncHooks
+            ? String(options.hooks.asyncHooks)
+            : undefined,
         }),
       );
-    }, 120000);
+    }, 240000);
 
     tests(getLogs);
   });


### PR DESCRIPTION
This pull request adds support for asynchronous hooks in `onFailFastTriggered` and `shouldTriggerFailFast` by allowing them to return a Promise. It also includes error handling that catches any errors or rejected Promises, logs a warning with `console.warn` (colored in yellow with the plugin's prefix), and continues execution normally (assuming `false` for `shouldTriggerFailFast`). Unit tests have been updated to maintain 100% coverage, and new E2E tests have been added to verify the async behavior using a `setTimeout` inside a Promise. Documentation and the changelog have been updated accordingly.

---
*PR created automatically by Jules for task [7105892929299543185](https://jules.google.com/task/7105892929299543185) started by @javierbrea*