### PR TITLE
feat: add describe strategy to skip only remaining tests in the failed describe block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+- feat: Add `describe` strategy, which skips only the remaining tests in the describe block where the failure happened. The skipped scope is the nearest ancestor describe carrying an explicit `failFast` configuration, or the failed test's immediate parent describe when there is none.
 ### Changed
 ### Fixed
 ### Removed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Skip the rest of your Cypress tests after the first failure.
 
 With Cypress Fail Fast, you can:
 
-- Skip all remaining tests in the current spec file, or in the entire run, depending on the configured strategy.
+- Skip all remaining tests in the current describe block, in the current spec file, or in the entire run, depending on the configured strategy.
 - Control fail-fast behavior at a per-test or per-suite level, so you can choose which failures should trigger fail-fast mode and which should not.
 - Set hooks to:
   - Run when fail-fast mode is triggered, so you can perform custom actions.
@@ -79,15 +79,20 @@ All plugin configuration is provided through the Cypress configuration file usin
 
 The following properties are supported:
 
-- `failFastStrategy`: `"spec" | "run"` (default: `"run"`)
+- `failFastStrategy`: `"spec" | "run" | "describe"` (default: `"run"`)
   - `"spec"`: Skip remaining tests only in the current spec file.  
   - `"run"` (default): Skip remaining tests in all spec files for the current run.  
+  - `"describe"`: Skip remaining tests only in the describe block where the failure happened. The skipped scope is resolved as follows:
+    - When any ancestor describe block of the failed test carries an explicit `failFast` configuration, the nearest one is used as the scope, so a failure anywhere inside a configured block (including nested describes) skips the remaining tests of that whole block.
+    - Otherwise, the scope is the immediate parent describe block of the failed test (nested describes inside it are also skipped).
+    - Describe blocks outside the scope, and the rest of the spec files, run normally. Note that fail-fast mode may be triggered again by a failure in another describe block, moving the skipped scope to that block.
+    - Note: describe blocks are identified by their title paths, so two sibling describe blocks with exactly the same title cannot be told apart. Use unique describe titles within a spec file when using this strategy.
 
 - `failFastEnabled`: `boolean` (default: `true`)  
   Enable or disable the fail-fast behavior globally. When set to `false`, fail-fast can still be enabled for specific tests or suites using per-test configuration.
 
 - `failFastBail`: `number` (default: `1`)  
-  Number of failing test suites required before entering fail-fast mode. For example, `failFastBail: 2` will start skipping tests after failures in two different suites or spec files, depending on the strategy. When strategy is `"spec"`, failures are reset at the beginning of each spec file, so fail-fast mode will be triggered after the configured number of failures within the same spec. When strategy is `"run"`, failures are tracked across the entire run, so fail-fast mode will be triggered after the configured number of failures regardless of which spec files they occur in.
+  Number of failing test suites required before entering fail-fast mode. For example, `failFastBail: 2` will start skipping tests after failures in two different suites or spec files, depending on the strategy. When strategy is `"spec"` or `"describe"`, failures are reset at the beginning of each spec file, so fail-fast mode will be triggered after the configured number of failures within the same spec. When strategy is `"run"`, failures are tracked across the entire run, so fail-fast mode will be triggered after the configured number of failures regardless of which spec files they occur in.
 
 - `failFastIgnorePerTestConfig`: `boolean` (default: `false`)  
   When `true`, the plugin ignores any per-test or per-suite `failFast` configuration and only uses the global options exposed through `expose`. This is useful when you want to control fail-fast exclusively at a global level (for example, disabling it completely or enabling it for the entire run) and avoid any accidental overrides in tests or suites.
@@ -207,11 +212,11 @@ Hooks allow you to run custom logic when fail-fast mode is triggered or to trigg
 Supported hooks:
 
 - `onFailFastTriggered`: Run custom logic when fail-fast mode is triggered. For example, you can use this hook to log additional information or to notify an external system. The hook receives an object with the following properties:
-  - `strategy`: The fail-fast strategy that is being applied (`"spec"` or `"run"`).
+  - `strategy`: The fail-fast strategy that is being applied (`"spec"`, `"run"` or `"describe"`).
   - `test`: The failed test that triggered fail-fast mode, with the following properties:
     - `name`: The title of the test that failed.
     - `fullTitle`: The full title of the test that failed, including the titles of its parent suites.
-- `shouldTriggerFailFast`: Trigger fail-fast mode at any moment based on custom logic. For example, you can use this hook to trigger fail-fast mode when a certain threshold of failures is reached across parallel runs. The hook should return `true` to trigger fail-fast mode or `false` to continue without triggering it. This hook is called before each test execution, so be careful with the performance of the logic implemented here.
+- `shouldTriggerFailFast`: Trigger fail-fast mode at any moment based on custom logic. For example, you can use this hook to trigger fail-fast mode when a certain threshold of failures is reached across parallel runs. The hook should return `true` to trigger fail-fast mode or `false` to continue without triggering it. This hook is called before each test execution, so be careful with the performance of the logic implemented here. Note that fail-fast mode triggered from this hook has no failed test attached, so, when the `"describe"` strategy is used, there is no describe block to scope the skipped tests to: every remaining test is skipped, as with the `"spec"` strategy.
 
 Both `onFailFastTriggered` and `shouldTriggerFailFast` support returning a Promise, allowing you to execute asynchronous operations like API calls or database queries inside the hooks. If a Promise is returned, the plugin will wait for it to resolve before continuing. If a hook throws an error or returns a rejected Promise, the error will be caught, a warning will be logged, and execution will continue normally (in the case of `shouldTriggerFailFast`, it will assume `false`).
 

--- a/src/Browser/CypressHelpers.spec.ts
+++ b/src/Browser/CypressHelpers.spec.ts
@@ -14,6 +14,7 @@ import {
   getTestConfig,
   failFastIsEnabled,
   testHasFailed,
+  getSkipScopeTitlePath,
 } from "./CypressHelpers";
 
 jest.mock("../Shared/Config", () => ({
@@ -127,6 +128,7 @@ describe("failFastIsEnabled", () => {
       ignorePerTestConfig: false,
       enabled: true,
       strategyIsSpec: false,
+      strategyIsDescribe: false,
       bail: 1,
     });
   });
@@ -207,5 +209,129 @@ describe("testHasFailed", () => {
     } as unknown as Mocha.Test;
 
     expect(testHasFailed(testLike)).toBe(false);
+  });
+});
+
+describe("getSkipScopeTitlePath", () => {
+  const cypressLike = {} as Cypress.Cypress;
+
+  beforeEach(() => {
+    mockedShouldIgnorePerTestConfig.mockReset();
+    mockedShouldIgnorePerTestConfig.mockReturnValue(false);
+  });
+
+  function createSuite({
+    title,
+    titlePath,
+    parent,
+    root = false,
+    failFast,
+  }: {
+    title: string;
+    titlePath?: string[];
+    parent?: Mocha.Suite;
+    root?: boolean;
+    failFast?: { enabled: boolean };
+  }): Mocha.Suite {
+    const suiteLike = {
+      title,
+      root,
+      parent,
+      titlePath: () => titlePath || [title],
+      _testConfig: failFast ? { failFast } : undefined,
+    };
+    return suiteLike as unknown as Mocha.Suite;
+  }
+
+  function createTestInSuite(parent: Mocha.Suite): Mocha.Test {
+    return { parent } as unknown as Mocha.Test;
+  }
+
+  it("returns the immediate parent describe when no suite has own fail-fast config", () => {
+    const rootSuite = createSuite({ title: "", root: true });
+    const parentSuite = createSuite({
+      title: "child suite",
+      titlePath: ["parent suite", "child suite"],
+      parent: rootSuite,
+    });
+    const currentTest = createTestInSuite(parentSuite);
+
+    expect(getSkipScopeTitlePath(currentTest, cypressLike)).toEqual([
+      "parent suite",
+      "child suite",
+    ]);
+  });
+
+  it("returns the nearest ancestor suite carrying own fail-fast config", () => {
+    const rootSuite = createSuite({ title: "", root: true });
+    const configuredSuite = createSuite({
+      title: "configured suite",
+      titlePath: ["configured suite"],
+      parent: rootSuite,
+      failFast: { enabled: true },
+    });
+    const innerSuite = createSuite({
+      title: "inner suite",
+      titlePath: ["configured suite", "inner suite"],
+      parent: configuredSuite,
+    });
+    const currentTest = createTestInSuite(innerSuite);
+
+    expect(getSkipScopeTitlePath(currentTest, cypressLike)).toEqual([
+      "configured suite",
+    ]);
+  });
+
+  it("reads suite config from unverifiedTestConfig shape", () => {
+    const rootSuite = createSuite({ title: "", root: true });
+    const configuredSuite = createSuite({
+      title: "configured suite",
+      titlePath: ["configured suite"],
+      parent: rootSuite,
+    });
+    // @ts-expect-error Mocked partially - reproducing the alternative private shape used by some Cypress versions
+    configuredSuite._testConfig = {
+      unverifiedTestConfig: { failFast: { enabled: true } },
+    };
+    const innerSuite = createSuite({
+      title: "inner suite",
+      titlePath: ["configured suite", "inner suite"],
+      parent: configuredSuite,
+    });
+    const currentTest = createTestInSuite(innerSuite);
+
+    expect(getSkipScopeTitlePath(currentTest, cypressLike)).toEqual([
+      "configured suite",
+    ]);
+  });
+
+  it("ignores suite own config when per-test config is ignored", () => {
+    mockedShouldIgnorePerTestConfig.mockReturnValue(true);
+
+    const rootSuite = createSuite({ title: "", root: true });
+    const configuredSuite = createSuite({
+      title: "configured suite",
+      titlePath: ["configured suite"],
+      parent: rootSuite,
+      failFast: { enabled: true },
+    });
+    const innerSuite = createSuite({
+      title: "inner suite",
+      titlePath: ["configured suite", "inner suite"],
+      parent: configuredSuite,
+    });
+    const currentTest = createTestInSuite(innerSuite);
+
+    expect(getSkipScopeTitlePath(currentTest, cypressLike)).toEqual([
+      "configured suite",
+      "inner suite",
+    ]);
+  });
+
+  it("returns an empty title path for tests defined at the spec root", () => {
+    const rootSuite = createSuite({ title: "", root: true });
+    const currentTest = createTestInSuite(rootSuite);
+
+    expect(getSkipScopeTitlePath(currentTest, cypressLike)).toEqual([]);
   });
 });

--- a/src/Browser/CypressHelpers.ts
+++ b/src/Browser/CypressHelpers.ts
@@ -69,6 +69,77 @@ export function failFastIsEnabled(
 }
 
 /**
+ * Reads a fail-fast override configured directly on a suite, if any.
+ *
+ * Suite-level configuration reaches tests through Cypress's merged
+ * `testConfigList` (see {@link getTestConfig}), but that merged list does not
+ * tell WHICH suite contributed the override. To attribute configuration to a
+ * concrete suite, this reads the raw config object that Cypress stores on the
+ * suite itself. The property is private and its shape has changed between
+ * Cypress versions, so both known shapes are checked defensively: when none
+ * matches, the caller falls back to a sane default (the immediate parent
+ * describe).
+ * @param suite Mocha suite instance.
+ * @returns The fail-fast override configured on that exact suite, if any.
+ */
+function getSuiteOwnConfig(
+  suite: Mocha.Suite,
+): Cypress.FailFastTestConfigOptions | undefined {
+  // @ts-expect-error - Accessing private property _testConfig is necessary to retrieve the failFast configuration defined at the suite level
+  const suiteConfig = suite._testConfig;
+  return suiteConfig?.failFast ?? suiteConfig?.unverifiedTestConfig?.failFast;
+}
+
+/**
+ * Resolves the describe block acting as skip scope for the `describe` strategy.
+ *
+ * The scope is the nearest ancestor suite carrying an explicit `failFast`
+ * configuration: when a user marks a describe block with fail-fast options, a
+ * failure anywhere inside it (including nested describes) should skip the
+ * remaining tests of that whole block. When no ancestor carries explicit
+ * configuration (fail-fast enabled globally), the scope falls back to the
+ * failed test's immediate parent describe, which is the most intuitive
+ * boundary: "skip the rest of this describe".
+ *
+ * Per-suite attribution is skipped when `failFastIgnorePerTestConfig` is set,
+ * because in that mode suite-level configuration must have no effect at all.
+ *
+ * @param currentTest Test that triggered fail-fast.
+ * @param Cyp Cypress global object.
+ * @returns Title path of the skip scope. An empty array means the test has no
+ * parent describe (it is defined at the spec root), in which case every
+ * remaining test in the spec is skipped, matching the `spec` strategy.
+ */
+export function getSkipScopeTitlePath(
+  currentTest: Mocha.Test,
+  Cyp: Cypress.Cypress,
+): string[] {
+  const parentSuite = currentTest.parent;
+  let scope: Mocha.Suite | undefined;
+
+  if (!shouldIgnorePerTestConfig(Cyp)) {
+    let suite: Mocha.Suite | undefined = parentSuite;
+    while (suite && !suite.root) {
+      if (getSuiteOwnConfig(suite)) {
+        scope = suite;
+        break;
+      }
+      suite = suite.parent;
+    }
+  }
+
+  if (!scope) {
+    scope = parentSuite;
+  }
+
+  if (!scope || scope.root) {
+    return [];
+  }
+
+  return scope.titlePath();
+}
+
+/**
  * Determines whether a test has definitively failed after exhausting retries.
  * @param currentTest Current Mocha test.
  * @returns `true` when the test is failed and has no remaining retries.

--- a/src/Browser/FailFast.spec.ts
+++ b/src/Browser/FailFast.spec.ts
@@ -14,24 +14,39 @@ import {
   FAILED_TEST_MESSAGE,
 } from "../Shared/Constants";
 
-import { bailConfig, currentStrategyIsSpec } from "../Shared/Config";
-import { failFastIsEnabled, testHasFailed, isHeaded } from "./CypressHelpers";
+import {
+  bailConfig,
+  currentStrategyIsSpec,
+  currentStrategyIsDescribe,
+} from "../Shared/Config";
+import {
+  failFastIsEnabled,
+  testHasFailed,
+  isHeaded,
+  getSkipScopeTitlePath,
+} from "./CypressHelpers";
 import { registerFailFast } from "./FailFast";
 
 jest.mock("../Shared/Config", () => ({
   bailConfig: jest.fn(),
   currentStrategyIsSpec: jest.fn(),
+  currentStrategyIsDescribe: jest.fn(),
 }));
 
 jest.mock("./CypressHelpers", () => ({
   failFastIsEnabled: jest.fn(),
   testHasFailed: jest.fn(),
   isHeaded: jest.fn(),
+  getSkipScopeTitlePath: jest.fn(),
 }));
 
 const mockedBailConfig = bailConfig as jest.MockedFunction<typeof bailConfig>;
 const mockedCurrentStrategyIsSpec =
   currentStrategyIsSpec as jest.MockedFunction<typeof currentStrategyIsSpec>;
+const mockedCurrentStrategyIsDescribe =
+  currentStrategyIsDescribe as jest.MockedFunction<
+    typeof currentStrategyIsDescribe
+  >;
 const mockedFailFastIsEnabled = failFastIsEnabled as jest.MockedFunction<
   typeof failFastIsEnabled
 >;
@@ -39,6 +54,8 @@ const mockedTestHasFailed = testHasFailed as jest.MockedFunction<
   typeof testHasFailed
 >;
 const mockedIsHeaded = isHeaded as jest.MockedFunction<typeof isHeaded>;
+const mockedGetSkipScopeTitlePath =
+  getSkipScopeTitlePath as jest.MockedFunction<typeof getSkipScopeTitlePath>;
 
 type HookCallback = (this: Mocha.Context) => void;
 
@@ -105,10 +122,15 @@ function createCyLike(initialShouldSkip = false, initialFailedTests = 0) {
   } as unknown as Cypress.cy;
 }
 
-function createCurrentTest(fullTitle = "a suite a test", title = "a test") {
+function createCurrentTest(
+  fullTitle = "a suite a test",
+  title = "a test",
+  titlePath = ["a suite", "a test"],
+) {
   return {
     title,
     fullTitle: () => fullTitle,
+    titlePath: () => titlePath,
   } as unknown as Mocha.Test;
 }
 
@@ -118,15 +140,19 @@ describe("registerFailFast", () => {
   beforeEach(() => {
     mockedBailConfig.mockReset();
     mockedCurrentStrategyIsSpec.mockReset();
+    mockedCurrentStrategyIsDescribe.mockReset();
     mockedFailFastIsEnabled.mockReset();
     mockedTestHasFailed.mockReset();
     mockedIsHeaded.mockReset();
+    mockedGetSkipScopeTitlePath.mockReset();
 
     mockedBailConfig.mockReturnValue(2);
     mockedCurrentStrategyIsSpec.mockReturnValue(false);
+    mockedCurrentStrategyIsDescribe.mockReturnValue(false);
     mockedFailFastIsEnabled.mockReturnValue(true);
     mockedTestHasFailed.mockReturnValue(false);
     mockedIsHeaded.mockReturnValue(false);
+    mockedGetSkipScopeTitlePath.mockReturnValue([]);
   });
 
   it("resets shared state in before hook when run is headed", () => {
@@ -202,9 +228,13 @@ describe("registerFailFast", () => {
 
     beforeHook.getCallback()?.call(context);
 
-    expect(cyLike.task).toHaveBeenCalledWith(SHOULD_SKIP_TASK, undefined, {
-      log: false,
-    });
+    expect(cyLike.task).toHaveBeenCalledWith(
+      SHOULD_SKIP_TASK,
+      { titlePath: undefined },
+      {
+        log: false,
+      },
+    );
     expect(context.skip).toHaveBeenCalledTimes(1);
   });
 
@@ -245,9 +275,13 @@ describe("registerFailFast", () => {
 
     beforeEachHook.getCallback()?.call(context);
 
-    expect(cyLike.task).toHaveBeenCalledWith(SHOULD_SKIP_TASK, undefined, {
-      log: false,
-    });
+    expect(cyLike.task).toHaveBeenCalledWith(
+      SHOULD_SKIP_TASK,
+      { titlePath: undefined },
+      {
+        log: false,
+      },
+    );
     expect(context.skip).toHaveBeenCalledTimes(1);
   });
 
@@ -412,6 +446,135 @@ describe("registerFailFast", () => {
         name: "a test",
         fullTitle: "suite should stop",
       },
+      skipScopeTitlePath: undefined,
     });
+  });
+
+  it("resets shared state in before hook when strategy is describe", () => {
+    const cyLike = createCyLike();
+    const beforeHook = createHookRegisterer();
+    const beforeEachHook = createHookRegisterer();
+    const afterEachHook = createHookRegisterer();
+    const context = { skip: jest.fn() } as unknown as Mocha.Context;
+
+    mockedCurrentStrategyIsDescribe.mockReturnValue(true);
+
+    registerFailFast(
+      cypressLike,
+      cyLike,
+      beforeHook.register,
+      beforeEachHook.register,
+      afterEachHook.register,
+    );
+
+    beforeHook.getCallback()?.call(context);
+
+    expect(cyLike.task).toHaveBeenCalledWith(RESET_SKIP_TASK, null, {
+      log: false,
+    });
+    expect(cyLike.task).toHaveBeenCalledWith(RESET_FAILED_TESTS_TASK, null, {
+      log: false,
+    });
+    expect(context.skip).not.toHaveBeenCalled();
+  });
+
+  it("sends current test title path to should-skip task in beforeEach hook", () => {
+    const cyLike = createCyLike(true);
+    const beforeHook = createHookRegisterer();
+    const beforeEachHook = createHookRegisterer();
+    const afterEachHook = createHookRegisterer();
+    const currentTest = createCurrentTest("a suite a test", "a test", [
+      "a suite",
+      "a test",
+    ]);
+    const context = {
+      skip: jest.fn(),
+      currentTest,
+    } as unknown as Mocha.Context;
+
+    registerFailFast(
+      cypressLike,
+      cyLike,
+      beforeHook.register,
+      beforeEachHook.register,
+      afterEachHook.register,
+    );
+
+    beforeEachHook.getCallback()?.call(context);
+
+    expect(cyLike.task).toHaveBeenCalledWith(
+      SHOULD_SKIP_TASK,
+      { titlePath: ["a suite", "a test"] },
+      {
+        log: false,
+      },
+    );
+    expect(context.skip).toHaveBeenCalledTimes(1);
+  });
+
+  it("enables skip mode with skip scope when strategy is describe and bail limit is reached", () => {
+    const cyLike = createCyLike(false, 0);
+    const beforeHook = createHookRegisterer();
+    const beforeEachHook = createHookRegisterer();
+    const afterEachHook = createHookRegisterer();
+    const currentTest = createCurrentTest("a suite should stop");
+    const context = {
+      currentTest,
+    } as unknown as Mocha.Context;
+
+    mockedTestHasFailed.mockReturnValue(true);
+    mockedFailFastIsEnabled.mockReturnValue(true);
+    mockedBailConfig.mockReturnValue(1);
+    mockedCurrentStrategyIsDescribe.mockReturnValue(true);
+    mockedGetSkipScopeTitlePath.mockReturnValue(["a suite"]);
+
+    registerFailFast(
+      cypressLike,
+      cyLike,
+      beforeHook.register,
+      beforeEachHook.register,
+      afterEachHook.register,
+    );
+
+    afterEachHook.getCallback()?.call(context);
+
+    expect(mockedGetSkipScopeTitlePath).toHaveBeenCalledTimes(1);
+    expect(mockedGetSkipScopeTitlePath.mock.calls[0]?.[0]).toBe(currentTest);
+    expect(mockedGetSkipScopeTitlePath.mock.calls[0]?.[1]).toBe(cypressLike);
+    expect(cyLike.task).toHaveBeenCalledWith(TRIGGER_FAIL_FAST_TASK, {
+      test: {
+        name: "a test",
+        fullTitle: "a suite should stop",
+      },
+      skipScopeTitlePath: ["a suite"],
+    });
+  });
+
+  it("does not resolve skip scope when strategy is not describe", () => {
+    const cyLike = createCyLike(false, 0);
+    const beforeHook = createHookRegisterer();
+    const beforeEachHook = createHookRegisterer();
+    const afterEachHook = createHookRegisterer();
+    const currentTest = createCurrentTest("a suite should stop");
+    const context = {
+      currentTest,
+    } as unknown as Mocha.Context;
+
+    mockedTestHasFailed.mockReturnValue(true);
+    mockedFailFastIsEnabled.mockReturnValue(true);
+    mockedBailConfig.mockReturnValue(1);
+    mockedCurrentStrategyIsDescribe.mockReturnValue(false);
+
+    registerFailFast(
+      cypressLike,
+      cyLike,
+      beforeHook.register,
+      beforeEachHook.register,
+      afterEachHook.register,
+    );
+
+    afterEachHook.getCallback()?.call(context);
+
+    expect(mockedGetSkipScopeTitlePath).not.toHaveBeenCalled();
   });
 });

--- a/src/Browser/FailFast.ts
+++ b/src/Browser/FailFast.ts
@@ -13,12 +13,22 @@ import {
 } from "../Shared/Constants";
 import type {
   FailFastFailedTestData,
+  ShouldSkipTaskPayload,
   TriggerFailFastTaskPayload,
 } from "../Node/Tasks.types";
 
-import { bailConfig, currentStrategyIsSpec } from "../Shared/Config";
+import {
+  bailConfig,
+  currentStrategyIsSpec,
+  currentStrategyIsDescribe,
+} from "../Shared/Config";
 
-import { failFastIsEnabled, testHasFailed, isHeaded } from "./CypressHelpers";
+import {
+  failFastIsEnabled,
+  testHasFailed,
+  isHeaded,
+  getSkipScopeTitlePath,
+} from "./CypressHelpers";
 
 /**
  * Registers Mocha hooks that implement fail-fast behavior in the browser process.
@@ -45,10 +55,19 @@ export function registerFailFast(
 
   /**
    * Reads the global skip flag from Node tasks.
+   *
+   * The title path of the test about to run is sent along so that the
+   * `describe` strategy can decide whether the test belongs to the describe
+   * block where fail-fast was triggered. Other strategies ignore it.
+   * @param currentTest Test about to run, when available.
    * @returns Cypress chainable resolving to skip state.
    */
-  function shouldSkip() {
-    return cy.task<boolean>(SHOULD_SKIP_TASK, undefined, { log: false });
+  function shouldSkip(currentTest?: Mocha.Test) {
+    return cy.task<boolean>(
+      SHOULD_SKIP_TASK,
+      { titlePath: currentTest?.titlePath() } as ShouldSkipTaskPayload,
+      { log: false },
+    );
   }
 
   /**
@@ -67,12 +86,23 @@ export function registerFailFast(
 
   /**
    * Enables skip mode for subsequent tests.
+   *
+   * With the `describe` strategy, the skip mode is scoped to the describe
+   * block of the test that triggered it, so only the remaining tests of that
+   * block are skipped. The scope has to be resolved here, in the browser,
+   * because the Mocha suite tree is not available in the Node process.
+   * @param failedTest Failed test data shared with Node-side hooks.
+   * @param skipScopeTitlePath Title path of the describe block to scope skip mode to.
    * @returns Cypress chainable resolving when skip mode is enabled.
    */
-  function enableSkipMode(failedTest: FailFastFailedTestData) {
+  function enableSkipMode(
+    failedTest: FailFastFailedTestData,
+    skipScopeTitlePath?: string[],
+  ) {
     log(SKIP_MESSAGE);
     return cy.task<void>(TRIGGER_FAIL_FAST_TASK, {
       test: failedTest,
+      skipScopeTitlePath,
     } as TriggerFailFastTaskPayload);
   }
 
@@ -108,9 +138,10 @@ export function registerFailFast(
   /**
    * Runs a callback only when skip mode is active.
    * @param callback Callback to execute in skip mode.
+   * @param currentTest Test about to run, used to evaluate scoped skip mode.
    */
-  function runIfSkipIsEnabled(callback: () => void) {
-    shouldSkip().then((value) => {
+  function runIfSkipIsEnabled(callback: () => void, currentTest?: Mocha.Test) {
+    shouldSkip(currentTest).then((value) => {
       if (value === true) {
         callback();
       }
@@ -124,13 +155,17 @@ export function registerFailFast(
   function skipSuiteIfEnabled(context: Mocha.Context) {
     runIfSkipIsEnabled(() => {
       context.skip();
-    });
+    }, context.currentTest);
   }
 
   before(function () {
-    if (isHeaded(Cyp) || currentStrategyIsSpec(Cyp)) {
+    if (
+      isHeaded(Cyp) ||
+      currentStrategyIsSpec(Cyp) ||
+      currentStrategyIsDescribe(Cyp)
+    ) {
       /*
-        Reset the shouldSkip flag at the start of a run, so that it doesn't carry over into subsequent runs. Do this only for headed runs because in headless runs, the `before` hook is executed for each spec file.
+        Reset the shouldSkip flag at the start of a run, so that it doesn't carry over into subsequent runs. Do this only for headed runs because in headless runs, the `before` hook is executed for each spec file. The `describe` strategy resets here for the same reason the `spec` strategy does: a describe block only exists within one spec file, so its skip scope must never leak into the next one.
       */
       resetSkipFlag();
       resetFailedTests();
@@ -153,7 +188,15 @@ export function registerFailFast(
     ) {
       log(`Test "${currentTest.fullTitle()}" has failed`);
       registerFailureAndRunIfBailLimitIsReached(() => {
-        enableSkipMode(mapFailedTest(currentTest));
+        /*
+          The skip scope is only resolved (and sent) for the `describe`
+          strategy: for `spec` and `run` an unscoped skip mode preserves the
+          previous behavior of skipping every remaining test.
+        */
+        const skipScopeTitlePath = currentStrategyIsDescribe(Cyp)
+          ? getSkipScopeTitlePath(currentTest, Cyp)
+          : undefined;
+        enableSkipMode(mapFailedTest(currentTest), skipScopeTitlePath);
       });
     }
   });

--- a/src/Node/Tasks.spec.ts
+++ b/src/Node/Tasks.spec.ts
@@ -324,4 +324,130 @@ describe("registerFailFastTasks", () => {
       `${chalk.yellow(LOG_PREFIX)} my message`,
     );
   });
+
+  describe("when skip mode is scoped to a describe block", () => {
+    const failedTest: FailFastFailedTestData = {
+      name: "failed test",
+      fullTitle: "First block failed test",
+    };
+
+    function createScopedTasks() {
+      const tasks = createRegisteredTasks(undefined, {
+        failFastStrategy: "describe",
+      });
+      return tasks;
+    }
+
+    it("skips tests inside the scoped describe block", async () => {
+      const tasks = createScopedTasks();
+
+      await tasks[TRIGGER_FAIL_FAST_TASK]({
+        test: failedTest,
+        skipScopeTitlePath: ["First block"],
+      });
+
+      expect(
+        await tasks[SHOULD_SKIP_TASK]({
+          titlePath: ["First block", "another test"],
+        }),
+      ).toBe(true);
+      expect(
+        await tasks[SHOULD_SKIP_TASK]({
+          titlePath: ["First block", "nested block", "another test"],
+        }),
+      ).toBe(true);
+    });
+
+    it("does not skip tests outside the scoped describe block", async () => {
+      const tasks = createScopedTasks();
+
+      await tasks[TRIGGER_FAIL_FAST_TASK]({
+        test: failedTest,
+        skipScopeTitlePath: ["First block"],
+      });
+
+      expect(
+        await tasks[SHOULD_SKIP_TASK]({
+          titlePath: ["Second block", "another test"],
+        }),
+      ).toBe(false);
+    });
+
+    it("skips tests conservatively when their title path is unknown", async () => {
+      const tasks = createScopedTasks();
+
+      await tasks[TRIGGER_FAIL_FAST_TASK]({
+        test: failedTest,
+        skipScopeTitlePath: ["First block"],
+      });
+
+      expect(await tasks[SHOULD_SKIP_TASK]()).toBe(true);
+      expect(await tasks[SHOULD_SKIP_TASK]({})).toBe(true);
+    });
+
+    it("clears the scope when skip state is reset", async () => {
+      const tasks = createScopedTasks();
+
+      await tasks[TRIGGER_FAIL_FAST_TASK]({
+        test: failedTest,
+        skipScopeTitlePath: ["First block"],
+      });
+      tasks[RESET_SKIP_TASK]();
+
+      expect(
+        await tasks[SHOULD_SKIP_TASK]({
+          titlePath: ["First block", "another test"],
+        }),
+      ).toBe(false);
+    });
+
+    it("replaces the scope when fail-fast is triggered again from another describe block", async () => {
+      const tasks = createScopedTasks();
+
+      await tasks[TRIGGER_FAIL_FAST_TASK]({
+        test: failedTest,
+        skipScopeTitlePath: ["First block"],
+      });
+      await tasks[TRIGGER_FAIL_FAST_TASK]({
+        test: failedTest,
+        skipScopeTitlePath: ["Second block"],
+      });
+
+      expect(
+        await tasks[SHOULD_SKIP_TASK]({
+          titlePath: ["Second block", "another test"],
+        }),
+      ).toBe(true);
+    });
+
+    it("skips every remaining test when skip mode is triggered without scope", async () => {
+      // Skip mode without a scope happens when it is triggered from the
+      // shouldTriggerFailFast hook, which has no failed test to derive a
+      // scope from.
+      const shouldTriggerFailFast = jest
+        .fn<() => boolean>()
+        .mockReturnValue(true);
+      const tasks = createRegisteredTasks(
+        {
+          hooks: {
+            shouldTriggerFailFast,
+          },
+        },
+        {
+          failFastStrategy: "describe",
+        },
+      );
+
+      expect(
+        await tasks[SHOULD_SKIP_TASK]({
+          titlePath: ["First block", "a test"],
+        }),
+      ).toBe(true);
+      expect(
+        await tasks[SHOULD_SKIP_TASK]({
+          titlePath: ["Second block", "a test"],
+        }),
+      ).toBe(true);
+    });
+  });
 });

--- a/src/Node/Tasks.ts
+++ b/src/Node/Tasks.ts
@@ -9,9 +9,10 @@ import {
   LOG_TASK,
   LOG_PREFIX,
 } from "../Shared/Constants";
-import { getFailFastPluginConfig } from "../Shared/Config";
+import { getFailFastPluginConfig, titlePathStartsWith } from "../Shared/Config";
 import type {
   FailFastPluginConfigOptions,
+  ShouldSkipTaskPayload,
   TriggerFailFastTaskPayload,
 } from "./Tasks.types";
 
@@ -29,6 +30,15 @@ export function registerFailFastTasks(
   // store skip flag
   let shouldSkipFlag = false;
   let failedTests = 0;
+  /*
+    Title path of the describe block where fail-fast was triggered. Only set by
+    the `describe` strategy: when present, skip mode affects only the tests
+    inside that describe block (or blocks nested in it), instead of every
+    remaining test. `null` means skip mode is unscoped (spec/run strategies, or
+    skip mode triggered from the `shouldTriggerFailFast` hook, which has no
+    failed test to derive a scope from).
+  */
+  let skipScopeTitlePath: string[] | null = null;
   const strategy = getFailFastPluginConfig(config).strategy;
 
   const shouldTriggerFailFastCallback =
@@ -53,15 +63,34 @@ export function registerFailFastTasks(
 
   /**
    * Computes whether remaining tests should be skipped.
-   * @returns `true` when skip mode is active.
+   * @param testTitlePath Title path of the test about to run, when known.
+   * @returns `true` when skip mode is active for that test.
    */
-  const shouldSkip = async () => {
-    if (shouldSkipFlag) {
-      return shouldSkipFlag;
+  const shouldSkip = async (testTitlePath?: string[]) => {
+    if (!shouldSkipFlag && (await shouldTriggerFailFastFromHook())) {
+      /*
+        Skip mode triggered from the hook has no failed test attached, so there
+        is no describe block to scope it to. Clear any previous scope to keep
+        the hook behavior consistent across strategies: it always skips every
+        remaining test (within the current spec for spec/describe strategies,
+        since those reset the flag at the beginning of each spec file).
+      */
+      shouldSkipFlag = true;
+      skipScopeTitlePath = null;
     }
 
-    if (await shouldTriggerFailFastFromHook()) {
-      shouldSkipFlag = true;
+    if (!shouldSkipFlag) {
+      return false;
+    }
+
+    /*
+      When skip mode is scoped to a describe block, only tests inside that
+      block are skipped: a test is inside the block when the block's title path
+      is a prefix of the test's title path. Tests with an unknown title path
+      are skipped conservatively, preserving the behavior of unscoped skip mode.
+    */
+    if (skipScopeTitlePath && testTitlePath) {
+      return titlePathStartsWith(testTitlePath, skipScopeTitlePath);
     }
 
     return shouldSkipFlag;
@@ -71,10 +100,11 @@ export function registerFailFastTasks(
   on("task", {
     [RESET_SKIP_TASK]: function () {
       shouldSkipFlag = false;
+      skipScopeTitlePath = null;
       return null;
     },
-    [SHOULD_SKIP_TASK]: async function () {
-      return await shouldSkip();
+    [SHOULD_SKIP_TASK]: async function (value?: ShouldSkipTaskPayload) {
+      return await shouldSkip(value?.titlePath);
     },
     [TRIGGER_FAIL_FAST_TASK]: async function (
       value: TriggerFailFastTaskPayload,
@@ -93,8 +123,9 @@ export function registerFailFastTasks(
       }
 
       shouldSkipFlag = true;
+      skipScopeTitlePath = value.skipScopeTitlePath || null;
 
-      return await shouldSkip();
+      return shouldSkipFlag;
     },
     [FAILED_TESTS_TASK]: function (value: boolean) {
       if (value === true) {

--- a/src/Node/Tasks.types.ts
+++ b/src/Node/Tasks.types.ts
@@ -45,6 +45,24 @@ export type FailFastHooks = {
  */
 export type TriggerFailFastTaskPayload = {
   test: FailFastFailedTestData;
+  /**
+   * Title path of the describe block where remaining tests must be skipped.
+   * Only provided when the `describe` strategy is active. When present, the
+   * skip mode only affects tests whose title path starts with this one.
+   */
+  skipScopeTitlePath?: string[];
+};
+
+/**
+ * Payload accepted by the should-skip task.
+ */
+export type ShouldSkipTaskPayload = {
+  /**
+   * Title path of the test about to run. Used by the `describe` strategy to
+   * decide whether the test belongs to the describe block where fail-fast was
+   * triggered. Other strategies ignore it.
+   */
+  titlePath?: string[];
 };
 
 /**

--- a/src/Shared/Config.spec.ts
+++ b/src/Shared/Config.spec.ts
@@ -16,11 +16,15 @@ import {
   isUndefined,
   RUN_STRATEGY,
   SPEC_STRATEGY,
+  DESCRIBE_STRATEGY,
   strategyIsSpec,
+  strategyIsDescribe,
   strategyValue,
+  titlePathStartsWith,
   getFailFastEnvironmentConfig,
   getFailFastPluginConfig,
   currentStrategyIsSpec,
+  currentStrategyIsDescribe,
   shouldIgnorePerTestConfig,
   bailConfig,
 } from "./Config";
@@ -85,11 +89,62 @@ describe("strategyIsSpec", () => {
   });
 });
 
+describe("strategyIsDescribe", () => {
+  it("returns true only when strategy is describe", () => {
+    expect(strategyIsDescribe(DESCRIBE_STRATEGY)).toBe(true);
+    expect(strategyIsDescribe(SPEC_STRATEGY)).toBe(false);
+    expect(strategyIsDescribe(RUN_STRATEGY)).toBe(false);
+  });
+});
+
 describe("strategyValue", () => {
-  it("returns spec for spec and run otherwise", () => {
+  it("returns spec or describe when provided and run otherwise", () => {
     expect(strategyValue(SPEC_STRATEGY)).toBe(SPEC_STRATEGY);
+    expect(strategyValue(DESCRIBE_STRATEGY)).toBe(DESCRIBE_STRATEGY);
     expect(strategyValue(RUN_STRATEGY)).toBe(RUN_STRATEGY);
     expect(strategyValue(undefined)).toBe(RUN_STRATEGY);
+  });
+});
+
+describe("titlePathStartsWith", () => {
+  it("returns true when scope is a prefix of the title path", () => {
+    expect(
+      titlePathStartsWith(["parent", "child", "test title"], ["parent"]),
+    ).toBe(true);
+    expect(
+      titlePathStartsWith(
+        ["parent", "child", "test title"],
+        ["parent", "child"],
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when scope equals the title path", () => {
+    expect(titlePathStartsWith(["parent", "child"], ["parent", "child"])).toBe(
+      true,
+    );
+  });
+
+  it("returns true when scope is empty", () => {
+    expect(titlePathStartsWith(["parent", "test title"], [])).toBe(true);
+  });
+
+  it("returns false when scope diverges from the title path", () => {
+    expect(
+      titlePathStartsWith(["parent", "child", "test title"], ["other parent"]),
+    ).toBe(false);
+    expect(
+      titlePathStartsWith(
+        ["parent", "child", "test title"],
+        ["parent", "other child"],
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when scope is longer than the title path", () => {
+    expect(
+      titlePathStartsWith(["parent"], ["parent", "child", "grandchild"]),
+    ).toBe(false);
   });
 });
 
@@ -107,6 +162,7 @@ describe("getFailFastEnvironmentConfig", () => {
       ignorePerTestConfig: GLOBAL_CONFIG_DEFAULT_VALUES[IGNORE_PER_TEST_CONFIG],
       enabled: GLOBAL_CONFIG_DEFAULT_VALUES[ENABLED_GLOBAL_CONFIG],
       strategyIsSpec: false,
+      strategyIsDescribe: false,
       bail: GLOBAL_CONFIG_DEFAULT_VALUES[BAIL_GLOBAL_CONFIG],
     });
   });
@@ -124,6 +180,7 @@ describe("getFailFastEnvironmentConfig", () => {
       ignorePerTestConfig: GLOBAL_CONFIG_DEFAULT_VALUES[IGNORE_PER_TEST_CONFIG],
       enabled: GLOBAL_CONFIG_DEFAULT_VALUES[ENABLED_GLOBAL_CONFIG],
       strategyIsSpec: false,
+      strategyIsDescribe: false,
       bail: 3,
     });
   });
@@ -141,6 +198,7 @@ describe("getFailFastEnvironmentConfig", () => {
       ignorePerTestConfig: true,
       enabled: false,
       strategyIsSpec: true,
+      strategyIsDescribe: false,
       bail: 2,
     });
   });
@@ -195,6 +253,18 @@ describe("helper config accessors", () => {
     });
 
     expect(currentStrategyIsSpec(cypressLike)).toBe(true);
+  });
+
+  it("returns strategyIsDescribe from currentStrategyIsDescribe", () => {
+    const cypressLike = createCypressLike({
+      [IGNORE_PER_TEST_CONFIG]: false,
+      [ENABLED_GLOBAL_CONFIG]: true,
+      [STRATEGY_GLOBAL_CONFIG]: "describe",
+      [BAIL_GLOBAL_CONFIG]: 1,
+    });
+
+    expect(currentStrategyIsDescribe(cypressLike)).toBe(true);
+    expect(currentStrategyIsSpec(cypressLike)).toBe(false);
   });
 
   it("returns ignorePerTestConfig from shouldIgnorePerTestConfig", () => {

--- a/src/Shared/Config.ts
+++ b/src/Shared/Config.ts
@@ -12,6 +12,7 @@ import { FailFastGlobalConfig } from "./Config.types";
 
 export const SPEC_STRATEGY = "spec" as const;
 export const RUN_STRATEGY = "run" as const;
+export const DESCRIBE_STRATEGY = "describe" as const;
 
 const truthyValuesSet = new Set([true, "true", 1, "1"]);
 const falsyValuesSet = new Set([false, "false", 0, "0"]);
@@ -54,6 +55,15 @@ export function strategyIsSpec(value: string) {
 }
 
 /**
+ * Checks if the provided strategy value equals `describe`.
+ * @param value Strategy value from Cypress env.
+ * @returns `true` when strategy is `describe`.
+ */
+export function strategyIsDescribe(value: string) {
+  return value === DESCRIBE_STRATEGY;
+}
+
+/**
  * Normalizes a strategy value to one of the supported strategy constants.
  * @param value Strategy value to normalize.
  * @returns Normalized strategy value.
@@ -61,7 +71,13 @@ export function strategyIsSpec(value: string) {
 export function strategyValue(
   value: unknown,
 ): FailFastGlobalConfig["strategy"] {
-  return strategyIsSpec(value as string) ? SPEC_STRATEGY : RUN_STRATEGY;
+  if (strategyIsSpec(value as string)) {
+    return SPEC_STRATEGY;
+  }
+  if (strategyIsDescribe(value as string)) {
+    return DESCRIBE_STRATEGY;
+  }
+  return RUN_STRATEGY;
 }
 
 function isDefined(value: unknown) {
@@ -104,6 +120,7 @@ export function getFailFastEnvironmentConfig(
       GLOBAL_CONFIG_DEFAULT_VALUES[ENABLED_GLOBAL_CONFIG],
     ),
     strategyIsSpec: strategy === SPEC_STRATEGY,
+    strategyIsDescribe: strategy === DESCRIBE_STRATEGY,
     bail: numericVarValue(
       Cyp.expose(BAIL_GLOBAL_CONFIG),
       GLOBAL_CONFIG_DEFAULT_VALUES[BAIL_GLOBAL_CONFIG],
@@ -132,6 +149,7 @@ export function getFailFastPluginConfig(
       GLOBAL_CONFIG_DEFAULT_VALUES[ENABLED_GLOBAL_CONFIG],
     ),
     strategyIsSpec: strategy === SPEC_STRATEGY,
+    strategyIsDescribe: strategy === DESCRIBE_STRATEGY,
     bail: numericVarValue(
       config.expose?.[BAIL_GLOBAL_CONFIG],
       GLOBAL_CONFIG_DEFAULT_VALUES[BAIL_GLOBAL_CONFIG],
@@ -146,6 +164,42 @@ export function getFailFastPluginConfig(
  */
 export function currentStrategyIsSpec(Cyp: Cypress.Cypress) {
   return getFailFastEnvironmentConfig(Cyp).strategyIsSpec;
+}
+
+/**
+ * Returns whether the current fail-fast strategy is `describe`.
+ * @param Cyp Cypress global object.
+ * @returns `true` when strategy is `describe`.
+ */
+export function currentStrategyIsDescribe(Cyp: Cypress.Cypress) {
+  return getFailFastEnvironmentConfig(Cyp).strategyIsDescribe;
+}
+
+/**
+ * Checks whether one title path is contained at the beginning of another.
+ *
+ * Used by the `describe` strategy to decide if a test belongs to the describe
+ * block (or any block nested inside it) where fail-fast was triggered: Mocha
+ * title paths are hierarchical, so a test is inside a suite when the suite's
+ * title path is a prefix of the test's title path.
+ *
+ * Note that title paths are the only suite identity available on both sides of
+ * the plugin (browser hooks and Node tasks), so two sibling describes with
+ * exactly the same title chain cannot be told apart. This limitation is
+ * documented in the README.
+ *
+ * @param titlePath Title path of the test being evaluated.
+ * @param scopeTitlePath Title path of the describe block acting as skip scope.
+ * @returns `true` when `scopeTitlePath` is a prefix of `titlePath`.
+ */
+export function titlePathStartsWith(
+  titlePath: string[],
+  scopeTitlePath: string[],
+): boolean {
+  if (scopeTitlePath.length > titlePath.length) {
+    return false;
+  }
+  return scopeTitlePath.every((title, index) => titlePath[index] === title);
 }
 
 /**

--- a/src/Shared/Config.types.ts
+++ b/src/Shared/Config.types.ts
@@ -10,6 +10,8 @@ export type FailFastGlobalConfig = {
   enabled: boolean;
   /** When `true`, the strategy that skips only the current spec after the first failure will be used. Otherwise, the strategy that skips all specs will be used. */
   strategyIsSpec: boolean;
+  /** When `true`, the strategy that skips only the remaining tests in the describe block where the failure happened will be used. */
+  strategyIsDescribe: boolean;
   /** Number of failures required to start skipping tests. */
   bail: number;
 };
@@ -19,8 +21,8 @@ export type FailFastConfig = {
   failFastIgnorePerTestConfig?: boolean;
   /** When `false`, fail-fast behavior is disabled. */
   failFastEnabled?: boolean;
-  /** When set to `"spec"`, the strategy that skips only the current spec after the first failure will be used. When set to `"run"`, the strategy that skips all specs will be used. */
-  failFastStrategy?: "spec" | "run";
+  /** When set to `"spec"`, the strategy that skips only the current spec after the first failure will be used. When set to `"run"`, the strategy that skips all specs will be used. When set to `"describe"`, only the remaining tests in the describe block where the failure happened will be skipped. */
+  failFastStrategy?: "spec" | "run" | "describe";
   /** Number of failures required to start skipping tests. */
   failFastBail?: number;
 };

--- a/test-e2e/cypress-latest/cypress/e2e/describe-strategy/a-file.cy.js
+++ b/test-e2e/cypress-latest/cypress/e2e/describe-strategy/a-file.cy.js
@@ -1,0 +1,43 @@
+// 6 tests distributed in two root describe blocks (the first one contains a
+// nested describe). With the "describe" strategy, the failure in the first
+// block must skip only the remaining tests of that block (including the ones
+// in its nested describe), while the second block must run normally:
+// 6 tests should be executed, 3 should pass, 1 should fail and 2 should be pending.
+
+describe("First block", () => {
+  beforeEach(() => {
+    cy.visit("/");
+  });
+
+  it("should display title", () => {
+    cy.get("h1").should("have.text", "Items list");
+  });
+
+  it("should display first item", () => {
+    cy.get("ul li:eq(0)").should("have.text", "Wrong text");
+  });
+
+  it("should display second item", () => {
+    cy.get("ul li:eq(1)").should("have.text", "Second item");
+  });
+
+  describe("Nested block", () => {
+    it("should display third item", () => {
+      cy.get("ul li:eq(2)").should("have.text", "Third item");
+    });
+  });
+});
+
+describe("Second block", () => {
+  beforeEach(() => {
+    cy.visit("/");
+  });
+
+  it("should display title", () => {
+    cy.get("h1").should("have.text", "Items list");
+  });
+
+  it("should display first item", () => {
+    cy.get("ul li:eq(0)").should("have.text", "First item");
+  });
+});

--- a/test-e2e/cypress-latest/cypress/e2e/describe-strategy/b-file.cy.js
+++ b/test-e2e/cypress-latest/cypress/e2e/describe-strategy/b-file.cy.js
@@ -1,0 +1,17 @@
+// 2 tests, both passing. The skip scope triggered in the previous spec file
+// must not leak into this one:
+// 2 tests should be executed, 2 should pass, 0 should fail and 0 should be pending.
+
+describe("Independent block", () => {
+  beforeEach(() => {
+    cy.visit("/");
+  });
+
+  it("should display title", () => {
+    cy.get("h1").should("have.text", "Items list");
+  });
+
+  it("should display first item", () => {
+    cy.get("ul li:eq(0)").should("have.text", "First item");
+  });
+});

--- a/test-e2e/cypress-latest/cypress/e2e/describe-strategy/c-file.cy.js
+++ b/test-e2e/cypress-latest/cypress/e2e/describe-strategy/c-file.cy.js
@@ -1,0 +1,37 @@
+// 4 tests. The failing test lives in a describe block nested inside a block
+// carrying an explicit failFast configuration, so the skip scope must be that
+// configured block: the sibling nested describe must also be skipped, while
+// the block outside the configured one must run normally:
+// 4 tests should be executed, 2 should pass, 1 should fail and 1 should be pending.
+
+describe("Configured block", { failFast: { enabled: true } }, () => {
+  beforeEach(() => {
+    cy.visit("/");
+  });
+
+  describe("Inner block with failure", () => {
+    it("should display title", () => {
+      cy.get("h1").should("have.text", "Items list");
+    });
+
+    it("should display first item", () => {
+      cy.get("ul li:eq(0)").should("have.text", "Wrong text");
+    });
+  });
+
+  describe("Inner sibling block", () => {
+    it("should display second item", () => {
+      cy.get("ul li:eq(1)").should("have.text", "Second item");
+    });
+  });
+});
+
+describe("Outside block", () => {
+  beforeEach(() => {
+    cy.visit("/");
+  });
+
+  it("should display third item", () => {
+    cy.get("ul li:eq(2)").should("have.text", "Third item");
+  });
+});

--- a/test-e2e/runner/specs/describe-strategy.spec.ts
+++ b/test-e2e/runner/specs/describe-strategy.spec.ts
@@ -1,0 +1,71 @@
+import { runSpecsTests } from "./support/TestsRunner";
+
+runSpecsTests("When describe strategy is set", {
+  cypressVariant: "cypress-latest",
+  specsFolder: "describe-strategy",
+  config: {
+    failFastStrategy: "describe",
+  },
+  specsResults: [
+    // First spec: the failure in the first describe block skips only the
+    // remaining tests of that block (including its nested describe), and the
+    // second describe block runs normally.
+    {
+      executed: 6,
+      passed: 3,
+      failed: 1,
+      pending: 2,
+    },
+    // Second spec: fully passing, proving the skip scope from the previous
+    // spec file does not leak into the next one.
+    {
+      executed: 2,
+      passed: 2,
+      failed: 0,
+      pending: 0,
+    },
+    // Third spec: the failure happens in a describe nested inside a block
+    // carrying explicit failFast configuration, so the whole configured block
+    // is skipped (including a sibling nested describe), while the describe
+    // outside it runs normally.
+    {
+      executed: 4,
+      passed: 2,
+      failed: 1,
+      pending: 1,
+    },
+  ],
+});
+
+runSpecsTests(
+  "When describe strategy is set and specs contain a single describe",
+  {
+    cypressVariant: "cypress-latest",
+    specsFolder: "no-config",
+    config: {
+      failFastStrategy: "describe",
+    },
+    // With a single root describe per spec file, the describe strategy behaves
+    // exactly like the spec strategy: the failing describe is the whole spec.
+    specsResults: [
+      {
+        executed: 4,
+        passed: 1,
+        failed: 1,
+        pending: 2,
+      },
+      {
+        executed: 4,
+        passed: 4,
+        failed: 0,
+        pending: 0,
+      },
+      {
+        executed: 3,
+        passed: 1,
+        failed: 1,
+        pending: 1,
+      },
+    ],
+  },
+);


### PR DESCRIPTION
## Description

This adds a new `describe` strategy (`failFastStrategy: "describe"`), which skips only the remaining tests in the describe block where the failure happened, instead of the whole spec file or run. It implements the request in issue #101, using the `this.skip()` approach made possible by v8.0.0.

How the skipped scope is resolved:

- When any ancestor describe block of the failed test carries an explicit `failFast` configuration, the nearest one is used as the scope. A failure anywhere inside a configured block (including nested describes) skips the remaining tests of that whole block.
- Otherwise, the scope is the failed test's immediate parent describe block (nested describes inside it are also skipped).
- Describe blocks outside the scope, and other spec files, run normally. A later failure in another block moves the scope to that block.
- The skip flag is reset at the start of each spec file, same as the `spec` strategy, so a scope never leaks into the next spec.

Implementation notes:

- The scope is resolved in the browser (where the Mocha suite tree lives) and sent to the Node task with the fail-fast trigger. The should-skip task then compares the title path of each test about to run against the scope by prefix match.
- Fail-fast triggered from the `shouldTriggerFailFast` hook has no failed test to derive a scope from, so it skips every remaining test, as with the `spec` strategy. Documented in the README.
- Describe blocks are identified by their title paths, so two sibling describes with exactly the same title cannot be told apart. Documented in the README.
- Unit tests keep 100% coverage, and a new E2E suite (`describe-strategy.spec.ts` with dedicated spec fixtures) covers: skipping only the failed block while a sibling block runs, no leak into the next spec file, and scoping to an ancestor block carrying explicit `failFast` configuration.

closes #101

## Agreement

Please check the following boxes after you have read and understood each item.

* [x] I have read the [CONTRIBUTING](https://github.com/javierbrea/cypress-fail-fast/blob/master/.github/CONTRIBUTING.md) document
* [x] I have read the [CODE_OF_CONDUCT](https://github.com/javierbrea/cypress-fail-fast/blob/master/.github/CODE_OF_CONDUCT.md) document
* [x] I have read the [CONTRIBUTOR LICENSE AGREEMENT](https://github.com/javierbrea/cypress-fail-fast/blob/master/.github/CLA.md) document, and I agree to the terms and declare that all my contributions are compliant with it.
